### PR TITLE
Unit Test Fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 build/
 dist/
 tweepy.egg-info/
+/testconf.py


### PR DESCRIPTION
Hi Josh,

I've updated the unit tests to work with OAuth now that twitter has shut off basic auth for their API.  I've done the following:
- To avoid users accidentally committing their credentials, they can now supply user/pass and tokens in testconf.py - this file has been added to .gitignore
- I have put instructions for using this in the module docstring
- I have written a simple command-line routine to help the tester grab their access token from twitter as long as they have supplied their app's consumer tokens.

Let me know if you want any other changes before pulling.

Regards,
Wayne
