### PR TITLE
Html characters like > and < now are correctly visible in status text

### DIFF
--- a/tweepy/models.py
+++ b/tweepy/models.py
@@ -61,6 +61,8 @@ class Status(Model):
                     setattr(status, 'source_url', None)
             elif k == 'retweeted_status':
                 setattr(status, k, Status.parse(api, v))
+            elif k=='text':
+                setattr(status, k, unescape_html(v))
             else:
                 setattr(status, k, v)
         return status


### PR DESCRIPTION
Hi Josh, I noticed that my application using tweepy libraries couldn't read statues where html characters were included in the text ( in particular I noticed this behavior with '<' and '>' characters) because Twitter's APIs don't allow html tag, obviously...This is not an issue, I know, but I think that in a desktop application an user of your libraries expects to find the same status text that is on a Twitter page...If he want to show the result on a web page through Tweepy, well, things change, but I think this case happens rarely...Anyway I "fixed" this..Bests..
