### PR TITLE
Add raw json to models

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -19,3 +19,4 @@ Guan Yang
 Michael Norton
 Adam Miskiewicz
 Chris Kelly
+Clay McClure

--- a/tweepy/models.py
+++ b/tweepy/models.py
@@ -45,6 +45,7 @@ class Status(Model):
     @classmethod
     def parse(cls, api, json):
         status = cls(api)
+        status._json = json
         for k, v in json.items():
             if k == 'user':
                 user = User.parse(api, v)
@@ -83,6 +84,7 @@ class User(Model):
     @classmethod
     def parse(cls, api, json):
         user = cls(api)
+        user._json = json
         for k, v in json.items():
             if k == 'created_at':
                 setattr(user, k, parse_datetime(v))
@@ -145,6 +147,7 @@ class DirectMessage(Model):
     @classmethod
     def parse(cls, api, json):
         dm = cls(api)
+        dm._json = json
         for k, v in json.items():
             if k == 'sender' or k == 'recipient':
                 setattr(dm, k, User.parse(api, v))
@@ -166,11 +169,13 @@ class Friendship(Model):
 
         # parse source
         source = cls(api)
+        source._json = json
         for k, v in relationship['source'].items():
             setattr(source, k, v)
 
         # parse target
         target = cls(api)
+        target._json = json
         for k, v in relationship['target'].items():
             setattr(target, k, v)
 
@@ -182,6 +187,7 @@ class SavedSearch(Model):
     @classmethod
     def parse(cls, api, json):
         ss = cls(api)
+        ss._json = json
         for k, v in json.items():
             if k == 'created_at':
                 setattr(ss, k, parse_datetime(v))
@@ -198,6 +204,7 @@ class SearchResult(Model):
     @classmethod
     def parse(cls, api, json):
         result = cls()
+        result._json = json
         for k, v in json.items():
             if k == 'created_at':
                 setattr(result, k, parse_search_datetime(v))
@@ -229,6 +236,7 @@ class List(Model):
     @classmethod
     def parse(cls, api, json):
         lst = List(api)
+        lst._json = json
         for k,v in json.items():
             if k == 'user':
                 setattr(lst, k, User.parse(api, v))


### PR DESCRIPTION
Howdy,

First, let me just say, tweepy rocks. Thank you!

I love the model abstraction, but what do y'all think about adding the ability to get at the raw json object emitted by twitter? My use case is fetching tweets and then dumping them onto a message queue for processing by another component in our system. The Tweepy model objects aren't easily serializable to JSON. I suppose I could use **dict**, but that doesn't exactly match what's returned by Twitter, and contains nested model objects that I'd have to deconstruct, also.

So I've patched models.py to store the raw json in a new _json attribute on each model instance.

I haven't updated the tests because I don't see many asserts in there to begin with, and they don't seem mocked, and I didn't want to create a new Twitter account just to run the tests. But I'd be happy to write tests for this feature once I have a better grasp of the test suite (and perhaps a way to mock Twitter so one doesn't need to have a real Twitter account to run the test suite).

Cheers,

Clay
