### PR TITLE
Improve verify credentials

### DIFF
--- a/tweepy/api.py
+++ b/tweepy/api.py
@@ -299,8 +299,10 @@ class API(object):
                 payload_type = 'user',
                 require_auth = True
             )(self)
-        except TweepError:
-            return False
+        except TweepError, e:
+            if e.response and e.response.status == 401:
+                return False
+            raise
 
     """ account/rate_limit_status """
     rate_limit_status = bind_api(


### PR DESCRIPTION
Howdy!

This patch prevents transient connection problems from causing verify_credentials() to return False. Instead, it will propagate the connection exception up to the caller. After the patch, verify_credentials() will return False only when authentication actually fails (HTTP status code 401).

Thanks,

Clay
