### PR TITLE
Overriding stack trace on streaming.py

### DIFF
--- a/tweepy/streaming.py
+++ b/tweepy/streaming.py
@@ -133,7 +133,7 @@ class Stream(object):
             conn.close()
 
         if exception:
-            raise exception
+            raise
 
     def _read_loop(self, resp):
           while self.running:


### PR DESCRIPTION
The "raise exception" is overriding the stack trace and hiding exceptions raised by listeners, a simple "raise" should be fine.
