### PR TITLE
Timeout with Python 2.5 compatibility

### DIFF
--- a/tweepy/api.py
+++ b/tweepy/api.py
@@ -18,7 +18,7 @@ class API(object):
             host='api.twitter.com', search_host='search.twitter.com',
              cache=None, secure=False, api_root='/1', search_root='',
             retry_count=0, retry_delay=0, retry_errors=None,
-            parser=None, timeout=None):
+            retry_timeout=True, parser=None, timeout=None):
         self.auth = auth_handler
         self.host = host
         self.search_host = search_host
@@ -29,6 +29,7 @@ class API(object):
         self.retry_count = retry_count
         self.retry_delay = retry_delay
         self.retry_errors = retry_errors
+        self.retry_timeout = retry_timeout
         self.parser = parser or ModelParser()
         self.timeout = timeout
 


### PR DESCRIPTION
I've implemented timeout support that uses httplib's timeout from Python2.6+ and sets the timeout directly on the HTTPConnection socket in previous versions of Python. I've also added a 'retry_timeout' argument that determines whether or not the request is retried when it times out.
