### PR TITLE
Added method for direct_messages/show

### DIFF
--- a/tweepy/api.py
+++ b/tweepy/api.py
@@ -212,6 +212,14 @@ class API(object):
         require_auth = True
     )
 
+    """ direct_messages/show """
+    get_direct_message = bind_api(
+        path = '/direct_messages/show/{id}.json',
+        payload_type = 'direct_message',
+        allowed_param = ['id'],
+        require_auth = True
+    )
+
     """ direct_messages/sent """
     sent_direct_messages = bind_api(
         path = '/direct_messages/sent.json',


### PR DESCRIPTION
The direct_messages/show method does exist in the Twitter API, even though it's currently missing from the documentation.

Here's the initial issue for the method: http://code.google.com/p/twitter-api/issues/detail?id=369
Here's a recent post on the Twitter Dev mailing list where Matt Harris (Twitter dev advocate) mentions it: https://groups.google.com/d/msg/twitter-development-talk/b3NGEaxX4oE/UzbxNKPYN3oJ

Cheers
