### PR TITLE
Add "entities" functionality to statuses/home_timeline (for URLs)

### DIFF
--- a/tweepy/api.py
+++ b/tweepy/api.py
@@ -42,7 +42,8 @@ class API(object):
     home_timeline = bind_api(
         path = '/statuses/home_timeline.json',
         payload_type = 'status', payload_list = True,
-        allowed_param = ['since_id', 'max_id', 'count', 'page'],
+        allowed_param = ['since_id', 'max_id', 'count', 'page',
+                         'include_entities'],
         require_auth = True
     )
 


### PR DESCRIPTION
As of August 15, 2011, Twitter wraps all URLs longer than 19 characters and includes link info whenever 'include_entities' is set to 'True.' [See this dev update for more info.](https://dev.twitter.com/discussions/1062) 

Per the article:

> We'll also be defaulting entities support on all responses that return tweets in the REST API soon, starting with entities being returned by default on POST statuses/update and POST direct_messages/new first and other methods to follow.

I have a website that deals with URLs in timelines, so I decided to add this functionality to api.py instead of waiting. I'll submit a pull request in a second.
