### PR TITLE
Fix for newer version of httplib

### DIFF
--- a/tweepy/api.py
+++ b/tweepy/api.py
@@ -747,7 +747,7 @@ class API(object):
         # build headers
         headers = {
             'Content-Type': 'multipart/form-data; boundary=Tw3ePy',
-            'Content-Length': len(body)
+            'Content-Length': str(len(body))
         }
 
         return headers, body


### PR DESCRIPTION
httplib in python 2.7 requires that the lenght parameter is a string
and not an int. Makes update_profile_image work again in Python 2.7.
