### PR TITLE
Handle SSL errors (such as timeouts!) and do exponential back off on errors 

### DIFF
--- a/tweepy/streaming.py
+++ b/tweepy/streaming.py
@@ -131,7 +131,7 @@ class Stream(object):
                     self._read_loop(resp)
             except (timeout, ssl.SSLError), exc:
                 # If it's not time out treat it like any other exception
-                if isinstance(exc, SSLError) and not (exc.args and 'timed out' in str(exc.args[0])):
+                if isinstance(exc, ssl.SSLError) and not (exc.args and 'timed out' in str(exc.args[0])):
                     exception = exc
                     break
 


### PR DESCRIPTION
Improved error handling, trap SSLError and pass exceptions to a handler for logging and exponential backoff on errors (required by twitter!)
