### PR TITLE
changed looping condition to check the status of the response.

### DIFF
--- a/tweepy/streaming.py
+++ b/tweepy/streaming.py
@@ -142,7 +142,8 @@ class Stream(object):
 
             # read length
             data = ''
-            while True:
+            # loop while server is giving an OK status
+            while resp.status >= 200 and resp.status < 300:
                 c = resp.read(1)
                 if c == '\n':
                     break


### PR DESCRIPTION
In response to Issue #41

Instead of looping on True. I changed it to loop so long as the server response is 2xx. I am unable to test as I don't have a development key but I don't think this will cause any problems and should be very fast to test.
