### PR TITLE
Encode track and follow parameters to UTF8.

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -378,6 +378,26 @@ class TweepyCacheTests(unittest.TestCase):
         self.cache.flush()
         os.rmdir('cache_test_dir')
 
+
+class TweepyStreamingTests(unittest.TestCase):
+
+    def testtrackencoding(self):
+        s = Stream(None, None)
+        s._start = lambda async: None
+        s.filter(track=[u'Caf\xe9'])
+
+        # Should be UTF-8 encoded
+        self.assertEqual(u'Caf\xe9'.encode('utf8'), s.parameters['track'])
+
+    def testfollowencoding(self):
+        s = Stream(None, None)
+        s._start = lambda async: None
+        s.filter(follow=[u'Caf\xe9'])
+
+        # Should be UTF-8 encoded
+        self.assertEqual(u'Caf\xe9'.encode('utf8'), s.parameters['follow'])
+
+
 if __name__ == '__main__':
     unittest.main()
 

--- a/tweepy/streaming.py
+++ b/tweepy/streaming.py
@@ -194,16 +194,19 @@ class Stream(object):
             self.url += '&count=%s' % count
         self._start(async)
 
-    def filter(self, follow=None, track=None, async=False, locations=None, count = None):
+    def filter(self, follow=None, track=None, async=False, locations=None,
+               count=None, encoding='utf8'):
         self.parameters = {}
         self.headers['Content-type'] = "application/x-www-form-urlencoded"
         if self.running:
             raise TweepError('Stream object already connected!')
         self.url = '/%i/statuses/filter.json?delimited=length' % STREAM_VERSION
         if follow:
-            self.parameters['follow'] = ','.join(map(str, follow))
+            encoded_follow = [s.encode(encoding) for s in follow]
+            self.parameters['follow'] = ','.join(encoded_follow)
         if track:
-            self.parameters['track'] = ','.join(map(str, track))
+            encoded_track = [s.encode(encoding) for s in track]
+            self.parameters['track'] = ','.join(encoded_track)
         if locations and len(locations) > 0:
             assert len(locations) % 4 == 0
             self.parameters['locations'] = ','.join(['%.2f' % l for l in locations])


### PR DESCRIPTION
The current streaming code simply calls str() on the track and follow arguments to filter. This will fail if there are non-ascii characters in these parameters.

The patch encodes these as UTF8 before adding to the streaming parameters.
