### PR TITLE
Use a buffer rather than reading the Twitter response one byte at a time...

### DIFF
--- a/tweepy/streaming.py
+++ b/tweepy/streaming.py
@@ -157,6 +157,8 @@ class Stream(object):
                 # buffer
                 buf += c
 
+        if resp.isclosed():
+            self.on_closed(resp)
 
     def _start(self, async):
         self.running = True
@@ -164,6 +166,10 @@ class Stream(object):
             Thread(target=self._run).start()
         else:
             self._run()
+
+    def on_closed(self, resp):
+        """ Called when the response has been closed by Twitter """
+        pass
 
     def userstream(self, count=None, async=False, secure=True):
         if self.running:


### PR DESCRIPTION
.... This actually respects the buffer_size option that was already there, but unused.

This improves performance from processing about 25 tweets/sec on my 2.8 GHz Core 2 Duo MacBook Pro pegging a core at 99% up to processing about 50/sec using 10% CPU.
