### PR TITLE
Adding support for gzip streams

### DIFF
--- a/tweepy/streaming.py
+++ b/tweepy/streaming.py
@@ -8,6 +8,7 @@ from threading import Thread
 from time import sleep
 import urllib
 import zlib
+from StringIO import StringIO
 
 from tweepy import __version__
 from tweepy.models import Status
@@ -147,20 +148,19 @@ class Stream(object):
 
     def _read_gzip_loop(self, resp):
         decompressor = zlib.decompressobj(16 + zlib.MAX_WBITS)
-        data = ''
+        data = StringIO()
         lines = []
 
         while self.running:
             if resp.isclosed():
                 break
-
             buf = decompressor.decompress(resp.read(self.buffer_size))
             for c in buf:
                 if c == '\n':
-                    lines.append(data.strip())
-                    data = ''
+                    lines.append(data.getvalue().strip())
+                    data = StringIO()
                 else:
-                    data += c
+                    data.write(c)
 
             if len(lines) > 0:
                 for line in lines:


### PR DESCRIPTION
Hi, stream.twitter.com now supports gzip compression which gives a big reduction in bandwidth.  I've patched tweepy to request and consume a gzip stream if the Stream object is created with a gzip=True parameter:

```
  auth = tweepy.auth.BasicAuthHandler(username, password)
  api = tweepy.API(auth)
  listen = Listener()
  stream = tweepy.Stream(auth, listen, gzip=True)
  stream.sample()
```
