### PR TITLE
lookup users API call doesn't require authentication. 

### DIFF
--- a/tweepy/api.py
+++ b/tweepy/api.py
@@ -175,7 +175,6 @@ class API(object):
         path = '/users/lookup.json',
         payload_type = 'user', payload_list = True,
         allowed_param = ['user_id', 'screen_name'],
-        require_auth = True
     )
 
     """ Get the authenticated user """


### PR DESCRIPTION
See the documentation at https://dev.twitter.com/docs/api/1/get/users/lookup and try the example: https://api.twitter.com/1/users/lookup.json?screen_name=twitterapi&include_entities=true
