### PR TITLE
exponential backoffs with twitter recommended values, loop hanging fix, better exception handling, and better status code handling

### DIFF
--- a/tweepy/streaming.py
+++ b/tweepy/streaming.py
@@ -77,8 +77,8 @@ class Stream(object):
         self.running = False
         self.timeout = options.get("timeout", 300.0)
         self.retry_count = options.get("retry_count")
-        self.retry_time = options.get("retry_time", 10.0)
-        self.max_retry_time = options.get("max_retry_time", 180.0)
+        self.retry_time = options.get("retry_time", 20.0)
+        self.max_retry_time = options.get("max_retry_time", 240.0)
         self.snooze_time = options.get("snooze_time",  5.0)
         self.buffer_size = options.get("buffer_size",  1500)
         if options.get("secure", True):
@@ -117,7 +117,11 @@ class Stream(object):
                     if self.listener.on_error(resp.status) is False:
                         break
                     error_counter += 1
-                    sleep(min(self.retry_time*error_counter, self.max_retry_time))
+                    if status_code==420: # wait longer
+                        sleep(min(self.retry_time, self.max_retry_time*2))
+                    else:
+                        sleep(min(self.retry_time, self.max_retry_time))
+                    self.retry_time = self.retry_time*2
                 else:
                     error_counter = 0
                     self._read_loop(resp)
@@ -133,7 +137,8 @@ class Stream(object):
                 self.listener.on_exception(exception)
                 error_counter += 1
                 conn.close()
-                sleep(min(self.retry_time*error_counter, self.max_retry_time))
+                sleep(min(self.retry_time, self.max_retry_time))
+                self.retry_time = self.retry_time*2
 
         # cleanup
         self.running = False


### PR DESCRIPTION
Backoffs according to https://dev.twitter.com/docs/streaming-api/user-streams/suggestions.  Exposes exceptions to the default client.  Loop hanging pulled in from here issue #135  Also includes recommended handling for 420 codes.
