### PR TITLE
2nd-last Tweet Issue

### DIFF
--- a/tweepy/streaming.py
+++ b/tweepy/streaming.py
@@ -157,9 +157,12 @@ class Stream(object):
                 delimited_string += d
 
             # read the next twitter status object
-            if delimited_string.isdigit():
-                next_status_obj = resp.read( int(delimited_string) )
+            try:
+                int_to_read = int(delimited_string)
+                next_status_obj = resp.read( int_to_read )
                 self._data(next_status_obj)
+            except ValueError:
+                pass
 
         if resp.isclosed():
             self.on_closed(resp)


### PR DESCRIPTION
With the streaming API, filter() only grabs the 2nd to last tweet, not the most recent one. This patch fixes this issue so that tweets come in real-time.

Copied from this Stack Overflow answer: http://stackoverflow.com/a/10368689/324978
