### PR TITLE
remove trailing characters that prevent streaming from pulling statuses

### DIFF
--- a/tweepy/streaming.py
+++ b/tweepy/streaming.py
@@ -156,6 +156,9 @@ class Stream(object):
                 d = resp.read(1)
                 delimited_string += d
 
+            # remove trailing \r\n
+            delimited_string = delimited_string[:-2]
+
             # read the next twitter status object
             if delimited_string.isdigit():
                 next_status_obj = resp.read( int(delimited_string) )


### PR DESCRIPTION
Twitter Streaming calls don't seem to work because it is running is_digit() on an integer containing a trailing \r\n. Didn't use strip() because wanted to prevent an extra operation in the loop.

See (https://dev.twitter.com/docs/streaming-api/concepts#parsing-responses)
