### PR TITLE
cleaned output stream by removing with strip

### DIFF
--- a/tweepy/streaming.py
+++ b/tweepy/streaming.py
@@ -155,6 +155,7 @@ class Stream(object):
             while d != '\n' and self.running and not resp.isclosed():
                 d = resp.read(1)
                 delimited_string += d
+            delimited_string = delimited_string.strip()
 
             # read the next twitter status object
             if delimited_string.isdigit():


### PR DESCRIPTION
While reading the delimited length in the stream output, there are more characters than expected, as 'new line' characters are added. Thus the delimited length never is a digit, the status is not processed and we are in an almost endless loop. Cleaning the string with a .strip() removes those characters and everything works as expected.
