### PR TITLE
Fix for issue #193: Call Exception.__init__ in TweepError constructor

### DIFF
--- a/tweepy/error.py
+++ b/tweepy/error.py
@@ -8,6 +8,7 @@ class TweepError(Exception):
     def __init__(self, reason, response=None):
         self.reason = unicode(reason)
         self.response = response
+        Exception.__init__(self, reason)
 
     def __str__(self):
         return self.reason


### PR DESCRIPTION
This fixes issue #193 in my testing over the last month or so.
