### PR TITLE
Add stall_warnings parameter support to streaming endpoint

### DIFF
--- a/tweepy/streaming.py
+++ b/tweepy/streaming.py
@@ -135,7 +135,7 @@ class Stream(object):
             raise
 
     def _data(self, data):
-        if self.listener.on_data(d) is False:
+        if self.listener.on_data(data) is False:
             self.running = False
 
     def _read_loop(self, resp):


### PR DESCRIPTION
This adds the `stall_warnings` parameter to the `Stream.filter` method.  
