### PR TITLE
Streaming client to use same timeout/retry semantics for https as for http

### DIFF
--- a/tweepy/streaming.py
+++ b/tweepy/streaming.py
@@ -4,7 +4,10 @@
 
 import httplib
 from socket import timeout
-from ssl import SSLError
+try:
+    from ssl import SSLError
+except ImportError:
+    class SSLError: pass
 from threading import Thread
 from time import sleep
 
@@ -116,7 +119,7 @@ class Stream(object):
                 else:
                     error_counter = 0
                     self._read_loop(resp)
-            except (timeout, SSLError) as e:
+            except (timeout, SSLError), e:
                 if isinstance(e, SSLError) and 'operation timed out' not in e.message:
                     raise # re-raise if not actually a timeout 
                 if self.listener.on_timeout() is False:


### PR DESCRIPTION
Currently retries after timeouts do not work for https. Timeouts when using https emanate from the ssl module, are of type ssl.SSLError and contain a certain message.

Obviously it'd be preferable to have been able to distinguish the timeout exceptions by their type alone, but alas.

The way I attempt to ensure compatibility with python 2.5 (which doesn't necessarily have ssl) is slightly unorthodox, but my assumption is that people won't be using https without the ssl module being available; a safe assumption, it seems to me. 
