### PR TITLE
Tweet Activity Summary Support (# favouriters, RTs & replies)

### DIFF
--- a/tweepy/api.py
+++ b/tweepy/api.py
@@ -134,6 +134,14 @@ class API(object):
         allowed_param = ['id']
     )
 
+    """ statuses/activity/summary """
+    get_status_activity = bind_api(
+        api_root = '/i',
+        path = '/statuses/{id}/activity/summary.json',
+        payload_type = 'statusactivity',
+        allowed_param = ['id']
+    )
+
     """ statuses/update """
     update_status = bind_api(
         path = '/statuses/update.json',

--- a/tweepy/binder.py
+++ b/tweepy/binder.py
@@ -26,6 +26,7 @@ def bind_api(**config):
         require_auth = config.get('require_auth', False)
         search_api = config.get('search_api', False)
         use_cache = config.get('use_cache', True)
+        api_root_config = config.get('api_root', None)
 
         def __init__(self, api, args, kargs):
             # If authentication is required and no credentials
@@ -44,6 +45,8 @@ def bind_api(**config):
             # Pick correct URL root to use
             if self.search_api:
                 self.api_root = api.search_root
+            if self.api_root_config:
+                self.api_root = self.api_root_config
             else:
                 self.api_root = api.api_root
 

--- a/tweepy/models.py
+++ b/tweepy/models.py
@@ -183,6 +183,20 @@ class Friendship(Model):
         return source, target
 
 
+class StatusActivity(Model):
+
+    @classmethod
+    def parse(cls, api, json):
+        summary = json
+
+        # parse source
+        activity = cls(api)
+        for k, v in summary.items():
+            setattr(activity, k, v)
+
+        return activity
+
+
 class Category(Model):
 
     @classmethod
@@ -408,6 +422,7 @@ class ModelFactory(object):
     """
 
     status = Status
+    statusactivity = StatusActivity
     user = User
     direct_message = DirectMessage
     friendship = Friendship


### PR DESCRIPTION
Hi Josh,

Added support for the unofficial tweet activity summary (# favouriters, RTs & replies) as used by popular twitter clients (official, tweetbot, ...) in an TweetActivity object. (API call: https://api.twitter.com/i/statuses/[tweet.id]/activity/summary.json).
