### PR TITLE
report_spam changed according to API 1.1 docs

### DIFF
--- a/tweepy/api.py
+++ b/tweepy/api.py
@@ -451,10 +451,10 @@ class API(object):
 
     """ report_spam """
     report_spam = bind_api(
-        path = '/report_spam.json',
+        path = '/users/report_spam.json',
         method = 'POST',
         payload_type = 'user',
-        allowed_param = ['id', 'user_id', 'screen_name'],
+        allowed_param = ['user_id', 'screen_name'],
         require_auth = True
     )
 


### PR DESCRIPTION
Hello,  
I've encountered that when attempting to report a user as spam there is an error "the page doesn't exist". So this tiny pull request hopefully resolves this.
