### PR TITLE
Possible solution for Issue 303

### DIFF
--- a/tweepy/cursor.py
+++ b/tweepy/cursor.py
@@ -87,9 +87,7 @@ class IdIterator(BaseIterator):
 
     def next(self):
         """Fetch a set of items with IDs less than current set."""
-        # max_id is inclusive so decrement by one
-        # to avoid requesting duplicate items.
-        max_id = self.since_id - 1 if self.max_id else None
+        max_id = self.since_id if self.max_id else None
         data = self.method(max_id = max_id, *self.args, **self.kargs)
         if len(data) == 0:
             raise StopIteration


### PR DESCRIPTION
Since the change to search API 1.1 this seems to be wrong. With decrement by 1
you will get the following error:
`tweepy.error.TweepError: [{'message': 'Missing or invalid url parameter', 'code': 195}]`
Removing it seems to resolve this without causing duplicates for us. However, more testing is needed. This seems to resolve issue #303
