### PR TITLE
should fix issue 303

### DIFF
--- a/tweepy/models.py
+++ b/tweepy/models.py
@@ -234,7 +234,7 @@ class SearchResults(ResultSet):
     @classmethod
     def parse(cls, api, json):
         metadata = json['search_metadata']
-        results = SearchResults(metadata.get('max_id'), metadata.get('since_id'))
+        results = SearchResults()
         results.refresh_url = metadata.get('refresh_url')
         results.completed_in = metadata.get('completed_in')
         results.query = metadata.get('query')


### PR DESCRIPTION
The idea is to let the underlying ResultSet handle since_id/max_id as used to generate subsequent API requests.

The since_id/max_id returned in the twitter search results metadata do not generally reflect the actual min/max id's retrieved, as twitter copies them from the request when present. Imho it's best just to ignore them for now...

I haven't checked if the search API returns most recent tweets first, but I think that's most probably the case. 
