### PR TITLE
Add /geo/place.json API method

### DIFF
--- a/tweepy/api.py
+++ b/tweepy/api.py
@@ -671,8 +671,16 @@ class API(object):
     """ geo/similar_places """
     geo_similar_places = bind_api(
         path = '/geo/similar_places.json',
-        payload_type = 'place', payload_list = True,
+        payload_type = 'json',
         allowed_param = ['lat', 'long', 'name', 'contained_within']
+    )
+
+    """ geo/place """
+    geo_place = bind_api(
+        path = '/geo/place.json',
+        method = 'POST',
+        payload_type = 'place',
+        allowed_param = ['lat', 'long', 'name', 'contained_within', 'token']
     )
 
     """ Internal use only """


### PR DESCRIPTION
Hi,

I just wanted to enable the creation of places with Tweepy so I added a missing API method.

Probably this can't be considered a proper pull request but I just wanted to bring your attention on this.

I exposed the token object in the response from geo_similar_places method and after that I add a new method for geo_place feature.

Cheers,
