### PR TITLE
Added support for Coveralls.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,3 +25,4 @@ env:
         JjlEyFWS487IFteR87U9pt18qongJJIphaBdT9/lDVLsMWZ0Jh5ZLQfX+2jS
         aF2UwsrYkzBUMrqMqYCc2+X6CuswLEZTVXDAlNh+emvhxZ5faMI=
 
+after_success: 'coveralls'

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -3,5 +3,5 @@
 if [[ $TRAVIS_SECURE_ENV_VARS == "false" ]]; then
   USE_REPLAY=1 nosetests -v tests.test_api tests.test_utils
 else
-  nosetests -v tests.test_api tests.test_streaming tests.test_cursors tests.test_utils
+  nosetests -v --with-coverage --cover-package=tweepy tests.test_api tests.test_streaming tests.test_cursors tests.test_utils
 fi

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,1 +1,2 @@
 httreplay==0.1.4
+coveralls==0.2


### PR DESCRIPTION
I've set up Tweepy to publish code coverage information to [Coveralls.io](http://coveralls.io), which allows you to display a badge in the README stating your test coverage. If you'd like to use this. you'll need to create an account at coveralls.io.

See [this repository](https://github.com/z4r/python-coveralls/blob/master/README.rst) for an example of the badge.
