### PR TITLE
Handle disconnect notices, log unknown messages

### DIFF
--- a/tweepy/streaming.py
+++ b/tweepy/streaming.py
@@ -2,6 +2,7 @@
 # Copyright 2009-2010 Joshua Roesslein
 # See LICENSE for details.
 
+import logging
 import httplib
 from socket import timeout
 from threading import Thread


### PR DESCRIPTION
I've been getting quite a few disconnect notices while running in a backend on app-engine. Poor handling of these disconnect notices has lead to rate limiting and 420 (enhance your cool) messages. This change is now in testing to see if it works better. I'd appreciate comments on whether you ( @joshthecoder ) like this approach.
