### PR TITLE
Still build a User even if no api is passed in

### DIFF
--- a/tweepy/models.py
+++ b/tweepy/models.py
@@ -66,7 +66,7 @@ class Status(Model):
         status = cls(api)
         for k, v in json.items():
             if k == 'user':
-                user_model = getattr(api.parser.model_factory, 'user')
+                user_model = getattr(api.parser.model_factory, 'user') if api else User
                 user = user_model.parse(api, v)
                 setattr(status, 'author', user)
                 setattr(status, 'user', user)  # DEPRECIATED


### PR DESCRIPTION
tweepy.models.Status.parse(None, json.loads(data))
fails without this fix. It seems the model_factory is rarely used anyway, so just using User directly is also a valid fix.
