### PR TITLE
Add unicode type detection for consumer key/secret

### DIFF
--- a/tweepy/auth.py
+++ b/tweepy/auth.py
@@ -28,6 +28,12 @@ class OAuthHandler(AuthHandler):
     OAUTH_ROOT = '/oauth/'
 
     def __init__(self, consumer_key, consumer_secret, callback=None, secure=False):
+        if type(consumer_key) == unicode:
+            consumer_key = bytes(consumer_key)
+
+        if type(consumer_secret) == unicode:
+            consumer_secret = bytes(consumer_secret)
+
         self._consumer = oauth.OAuthConsumer(consumer_key, consumer_secret)
         self._sigmethod = oauth.OAuthSignatureMethod_HMAC_SHA1()
         self.request_token = None


### PR DESCRIPTION
The hmac module won't accept unicode objects so cast them before using
them if they're present.

I have some python-spidermonkey code, which uses unicode objects exclusively (much like py3), so I needed some code in tweepy to automatically handle incoming unicode consumer key/secrets and cast them as bytes so the hmac module doesn't throw a fit. This will be necessary for py3 support as well (I think).
