### PR TITLE
Added optional language filter on sample endpoint

### DIFF
--- a/tweepy/streaming.py
+++ b/tweepy/streaming.py
@@ -222,13 +222,18 @@ class Stream(object):
         self.url = '/%s/statuses/retweet.json?delimited=length' % STREAM_VERSION
         self._start(async)
 
-    def sample(self, count=None, async=False):
-        self.parameters = {'delimited': 'length'}
+    def sample(self, count=None, async=False, languages=None):
+        self.parameters = {}
+        self.headers['Content-type'] = "application/x-www-form-urlencoded"
         if self.running:
             raise TweepError('Stream object already connected!')
         self.url = '/%s/statuses/sample.json?delimited=length' % STREAM_VERSION
+        if languages:
+            self.parameters['language'] = ','.join(map(str, languages))
         if count:
             self.url += '&count=%s' % count
+        self.body = urlencode_noplus(self.parameters)
+        self.parameters['delimited'] = 'length'
         self._start(async)
 
     def filter(self, follow=None, track=None, async=False, locations=None, 


### PR DESCRIPTION
Resolves Issue #291 

I found that filtering on language alone can only be done through the sample endpoint on the streaming API. This problem was brought up in issue 291 (filtering on language alone will result in 406 error), originally caused by twitter not supporting language, but now caused by filter apparently only filtering on track or location.

specifying language in sample seems to fix the problem for me.
