### PR TITLE
Added new param (include_rts) to list_timeline

### DIFF
--- a/tweepy/api.py
+++ b/tweepy/api.py
@@ -534,7 +534,7 @@ class API(object):
     list_timeline = bind_api(
         path = '/lists/statuses.json',
         payload_type = 'status', payload_list = True,
-        allowed_param = ['owner_screen_name', 'slug', 'owner_id', 'list_id', 'since_id', 'max_id', 'count']
+        allowed_param = ['owner_screen_name', 'slug', 'owner_id', 'list_id', 'since_id', 'max_id', 'count', 'include_rts']
     )
 
     get_list = bind_api(


### PR DESCRIPTION
Needed to pull statuses from a twitter list without RTs (which the twitter api includes by default). Made this modification and included 'include_rts=0' in my request to get a list of tweets sans-RTs.
