### PR TITLE
Add statuses/update_with_media feature

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -70,6 +70,10 @@ class TweepyAPITests(TweepyTestCase):
         deleted = self.api.destroy_status(id=update.id)
         self.assertEqual(deleted.id, update.id)
 
+    def testupdatestatuswithmedia(self):
+        update = self.api.update_with_media('examples/banner.png', status=tweet_text)
+        self.assertEqual(update.text, text)
+
     def testgetuser(self):
         u = self.api.get_user('twitter')
         self.assertEqual(u.screen_name, 'twitter')

--- a/tweepy/api.py
+++ b/tweepy/api.py
@@ -89,6 +89,22 @@ class API(object):
         require_auth = True
     )
 
+    """ statuses/update_with_media """
+    def update_with_media(self, filename, *args, **kwargs):
+        headers, post_data = API._pack_image(filename, 3072, form_field='media[]')
+        kwargs.update({'headers': headers, 'post_data': post_data})
+
+        return bind_api(
+            path='/statuses/update_with_media.json',
+            method = 'POST',
+            payload_type='status',
+            allowed_param = [
+                'status', 'possibly_sensitive', 'in_reply_to_status_id', 'lat', 'long',
+                'place_id', 'display_coordinates'
+            ],
+            require_auth=True
+        )(self, *args, **kwargs)
+
     """ statuses/destroy """
     destroy_status = bind_api(
         path = '/statuses/destroy/{id}.json',


### PR DESCRIPTION
See https://dev.twitter.com/docs/api/1.1/post/statuses/update_with_media

implement support for the update_with_media feature + test.

This code is based on another pull request (https://github.com/tweepy/tweepy/pull/180) but that PR is not compliant with the v1.1 of the Twitter api. 

> Important: In API v1.1, you now use api.twitter.com as the domain instead of upload.twitter.com.

very small code added.

See discussion on issue #119
