### PR TITLE
Added count parameter to search API method

### DIFF
--- a/tweepy/api.py
+++ b/tweepy/api.py
@@ -621,7 +621,7 @@ class API(object):
     search = bind_api(
         path = '/search/tweets.json',
         payload_type = 'search_results',
-        allowed_param = ['q', 'lang', 'locale', 'since_id', 'geocode', 'show_user', 'max_id', 'since', 'until', 'result_type']
+        allowed_param = ['q', 'lang', 'locale', 'since_id', 'geocode', 'show_user', 'max_id', 'since', 'until', 'result_type', 'count']
     )
 
     """ trends/daily """


### PR DESCRIPTION
Twitter search API has "count" parameter that allows to specify maximum amount of results per page. I added support for this parameter to tweepy.
