### PR TITLE
Deploy to PyPI when a commit is tagged

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,3 +31,13 @@ env:
         aF2UwsrYkzBUMrqMqYCc2+X6CuswLEZTVXDAlNh+emvhxZ5faMI=
 
 after_success: 'if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then coveralls; fi'
+
+deploy:
+  provider: pypi
+  user: ""
+  password: ""
+  on:
+    tags: true
+    branch: master
+    python: 2.7
+    repo: "tweepy/tweepy"


### PR DESCRIPTION
This resolves issue https://github.com/tweepy/tweepy/issues/382.

@joshthecoder: You'll need to update this with your encrypted PyPI username and password. See [here](http://docs.travis-ci.com/user/encryption-keys/) for details.
