### PR TITLE
Removed all use of non secure and http protocol 

### DIFF
--- a/tweepy/api.py
+++ b/tweepy/api.py
@@ -25,7 +25,7 @@ class API(object):
         self.api_root = api_root
         self.search_root = search_root
         self.cache = cache
-        self.secure = secure
+        self.secure = True
         self.compression = compression
         self.retry_count = retry_count
         self.retry_delay = retry_delay

--- a/tweepy/auth.py
+++ b/tweepy/auth.py
@@ -27,7 +27,7 @@ class OAuthHandler(AuthHandler):
     OAUTH_HOST = 'api.twitter.com'
     OAUTH_ROOT = '/oauth/'
 
-    def __init__(self, consumer_key, consumer_secret, callback=None, secure=True):
+    def __init__(self, consumer_key, consumer_secret, callback=None):
         if type(consumer_key) == unicode:
             consumer_key = bytes(consumer_key)
 
@@ -39,16 +39,10 @@ class OAuthHandler(AuthHandler):
         self.request_token = None
         self.access_token = None
         self.callback = callback
-        self.username = None
-        self.secure = secure
+        self.username = None        
 
-    def _get_oauth_url(self, endpoint, secure=True):
-        if self.secure or secure:
-            prefix = 'https://'
-        else:
-            prefix = 'http://'
-
-        return prefix + self.OAUTH_HOST + self.OAUTH_ROOT + endpoint
+    def _get_oauth_url(self, endpoint):                
+        return 'https://' + self.OAUTH_HOST + self.OAUTH_ROOT + endpoint
 
     def apply_auth(self, url, method, headers, parameters):
         request = oauth.OAuthRequest.from_consumer_and_token(
@@ -126,7 +120,7 @@ class OAuthHandler(AuthHandler):
         and request activation of xAuth for it.
         """
         try:
-            url = self._get_oauth_url('access_token', secure=True) # must use HTTPS
+            url = self._get_oauth_url('access_token') # must use HTTPS
             request = oauth.OAuthRequest.from_consumer_and_token(
                 oauth_consumer=self._consumer,
                 http_method='POST', http_url=url,

--- a/tweepy/binder.py
+++ b/tweepy/binder.py
@@ -50,13 +50,8 @@ def bind_api(**config):
                 self.api_root = api.api_root
 
             # Perform any path variable substitution
-            self.build_path()
-
-            if api.secure:
-                self.scheme = 'https://'
-            else:
-                self.scheme = 'http://'
-
+            self.build_path()                    
+            
             if self.search_api:
                 self.host = api.search_host
             else:
@@ -132,16 +127,13 @@ def bind_api(**config):
             # or maximum number of retries is reached.
             retries_performed = 0
             while retries_performed < self.retry_count + 1:
-                # Open connection
-                if self.api.secure:
-                    conn = httplib.HTTPSConnection(self.host, timeout=self.api.timeout)
-                else:
-                    conn = httplib.HTTPConnection(self.host, timeout=self.api.timeout)
-
+                # Open connection            
+                conn = httplib.HTTPSConnection(self.host, timeout=self.api.timeout)
+                
                 # Apply authentication
                 if self.api.auth:
                     self.api.auth.apply_auth(
-                            self.scheme + self.host + url,
+                            'https://' + self.host + url,
                             self.method, self.headers, self.parameters
                     )
 

--- a/tweepy/streaming.py
+++ b/tweepy/streaming.py
@@ -123,11 +123,7 @@ class Stream(object):
         self.retry_time_cap = options.get("retry_time_cap", 320.0)
         self.snooze_time_step = options.get("snooze_time", 0.25)
         self.snooze_time_cap = options.get("snooze_time_cap", 16)
-        self.buffer_size = options.get("buffer_size",  1500)
-        if options.get("secure", True):
-            self.scheme = "https"
-        else:
-            self.scheme = "http"
+        self.buffer_size = options.get("buffer_size",  1500)        
 
         self.api = API()
         self.headers = options.get("headers") or {}
@@ -138,7 +134,7 @@ class Stream(object):
 
     def _run(self):
         # Authenticate
-        url = "%s://%s%s" % (self.scheme, self.host, self.url)
+        url = "https://%s%s" % ( self.host, self.url)
 
         # Connect and process the stream
         error_counter = 0
@@ -149,10 +145,8 @@ class Stream(object):
                 # quit if error count greater than retry count
                 break
             try:
-                if self.scheme == "http":
-                    conn = httplib.HTTPConnection(self.host, timeout=self.timeout)
-                else:
-                    conn = httplib.HTTPSConnection(self.host, timeout=self.timeout)
+                
+                conn = httplib.HTTPSConnection(self.host, timeout=self.timeout)
                 self.auth.apply_auth(url, 'POST', self.headers, self.parameters)
                 conn.connect()
                 conn.request('POST', self.url, self.body, headers=self.headers)


### PR DESCRIPTION
Removed all use of non secure and http protocol as Twitter API is now https only

Maintained the secure parameter on the API class for consistency, but it now defaults to secure in all cases.

Replaced any branch logic that gave the option of http over https.
