### PR TITLE
More Precision in Coordinate-Search

### DIFF
--- a/tweepy/streaming.py
+++ b/tweepy/streaming.py
@@ -301,7 +301,7 @@ class Stream(object):
             self.parameters['track'] = ','.join(encoded_track)
         if locations and len(locations) > 0:
             assert len(locations) % 4 == 0
-            self.parameters['locations'] = ','.join(['%.2f' % l for l in locations])
+            self.parameters['locations'] = ','.join(['%.4f' % l for l in locations])
         if count:
             self.parameters['count'] = count
         if stall_warnings:


### PR DESCRIPTION
Two decimal places do not allow the to specify an area exactly.
