### PR TITLE
Only call _data if stream.running=True

### DIFF
--- a/tweepy/streaming.py
+++ b/tweepy/streaming.py
@@ -223,7 +223,8 @@ class Stream(object):
             # read the next twitter status object
             if delimited_string.strip().isdigit():
                 next_status_obj = resp.read( int(delimited_string) )
-                self._data(next_status_obj)
+                if self.running:
+                    self._data(next_status_obj)
 
         if resp.isclosed():
             self.on_closed(resp)


### PR DESCRIPTION
Not sure why an extra delimiter is spit out when you disconnect, but this should be enough of a bandaid.

We could alternately check that next_status_obj is a dict and throw an error otherwise.
