### PR TITLE
Add _json field to user and status models

### DIFF
--- a/tweepy/models.py
+++ b/tweepy/models.py
@@ -68,6 +68,7 @@ class Status(Model):
     @classmethod
     def parse(cls, api, json):
         status = cls(api)
+        setattr(status, '_json', json)
         for k, v in json.items():
             if k == 'user':
                 user_model = getattr(api.parser.model_factory, 'user') if api else User
@@ -112,6 +113,7 @@ class User(Model):
     @classmethod
     def parse(cls, api, json):
         user = cls(api)
+        setattr(user, '_json', json)
         for k, v in json.items():
             if k == 'created_at':
                 setattr(user, k, parse_datetime(v))


### PR DESCRIPTION
It is sometimes useful to have access to fields that `tweepy` doesn't define on it's model objects. This suggestion adds a `_json` field with the raw data.
