### PR TITLE
Fix tweepy.API.update_with_media with unicode filename

### DIFF
--- a/tweepy/api.py
+++ b/tweepy/api.py
@@ -790,7 +790,8 @@ class API(object):
             raise TweepError('Invalid file type for image: %s' % file_type)
 
         if isinstance(filename, unicode):
-          filename = urllib.quote(filename.encode("utf-8"))
+          filename = filename.encode("utf-8")
+        filename = urllib.quote(filename)
 
 
         BOUNDARY = 'Tw3ePy'


### PR DESCRIPTION
If filename is an instance of `unicode`,
L.76 `'Content-Disposition: form-data; name="%s"; filename="%s"' % (form_field, filename)`
must be unicode string like following.

----pprinting of `body`----
    ['--Tw3ePy',
     u'Content-Disposition: form-data; name="media[]"; filename="/tmp/tmpBirD24-memo.png"',
     'Content-Type: image/png',
     '',
     '\x89PNG\r\n(binary)'
     '--Tw3ePy--',
     '']

Because of it, L. 803 `body = '\r\n'.join(body)` fails with UnicodeDecodeError.

Therefore, I made `filename` designed to be percent-encoded str
before formatting.
