### PR TITLE
reword rate limit notify msg

### DIFF
--- a/tweepy/binder.py
+++ b/tweepy/binder.py
@@ -140,7 +140,7 @@ def bind_api(**config):
                     sleep_time = self._reset_time - int(time.time())
                     if sleep_time > 0:
                         if self.wait_on_rate_limit_notify:
-                            print "Max retries reached. Sleeping for: " + str(sleep_time)
+                            print "Rate limit reached. Sleeping for: " + str(sleep_time)
                         time.sleep(sleep_time + 5)  # sleep for few extra sec
 
                 # Apply authentication


### PR DESCRIPTION
Maybe it's just me, but when I saw this msg I thought I was getting errors and hitting my retry_count. When it had a high number for the sleep time (much higher than my retry_delay) I realized it was the rate limit logic. Looks like this will only get printed during rate limiting so it might be worth changing. 
