### PR TITLE
Change to make sure tweepy use SSL

### DIFF
--- a/examples/oauth.py
+++ b/examples/oauth.py
@@ -17,6 +17,7 @@ access_token=""
 access_token_secret=""
 
 auth = tweepy.OAuthHandler(consumer_key, consumer_secret)
+auth.secure = True
 auth.set_access_token(access_token, access_token_secret)
 
 api = tweepy.API(auth)


### PR DESCRIPTION
I had some problems using Tweepy and I realized it was because it didn't always use SSL. So I propose to add a line to make sure the connexion we use is secure.
