### PR TITLE
Status model from Model Factory

### DIFF
--- a/tweepy/models.py
+++ b/tweepy/models.py
@@ -248,8 +248,10 @@ class SearchResults(ResultSet):
         results.count = metadata.get('count')
         results.next_results = metadata.get('next_results')
 
+        status_model = getattr(api.parser.model_factory, 'status') if api else Status
+
         for status in json['statuses']:
-            results.append(Status.parse(api, status))
+            results.append(status_model.parse(api, status))
         return results
 
 


### PR DESCRIPTION
I was confusing at first when sometimes the models from the factory are called like:

```
status_model = getattr(api.parser.model_factory, 'status') if api else Status
```

Example: [here](https://github.com/tweepy/tweepy/blob/master/tweepy/models.py#L76)
And sometimes in this way:

```
 setattr(user, k, Status.parse(api, v))
```

Example: [here](https://github.com/tweepy/tweepy/blob/master/tweepy/models.py#L123)

I think the best way is always call the models instances from the factory, but like that requires a more refactoring I've created this PR just with the SearchResult model.

Please give your thoughts.
