### PR TITLE
"cd tweepy" command after git clone in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ You may also use Git to clone the repository from
 Github and install it manually:
 
     git clone https://github.com/tweepy/tweepy.git
+    cd tweepy
     python setup.py install
 
 **Note** only Python 2.6 and 2.7 are supported at


### PR DESCRIPTION
Missing "cd tweepy" command after git clone in README.md in installation instructions
