### PR TITLE
Update the required version of the requests package (requirement.txt)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-requests==1.2.3
+requests>=2.0.0
 requests_oauthlib==0.4.0


### PR DESCRIPTION
When installing tweepy from git repository the following raises:

"error: Installed distribution requests 1.2.3 conflicts with requirement requests>=2.0.0"

To fix it the version of the requests package has to be update at least to 2.0.0. This is what this patch does.
