### PR TITLE
Comparison between Status object

### DIFF
--- a/tweepy/models.py
+++ b/tweepy/models.py
@@ -118,6 +118,14 @@ class Status(Model):
 
         return NotImplemented
 
+    def __ne__(self, other):
+        result = self == other
+
+        if result is NotImplemented:
+            return result
+
+        return not result
+
 
 class User(Model):
 


### PR DESCRIPTION
tweepy.models.Status has no comparison method. so same status from `api.home_timeline()` and `api.mentions_timeline()` are marked as different.
It should be better when it has comparison method
