### PR TITLE
Fix sample to use Requests instead of httplib

### DIFF
--- a/tweepy/streaming.py
+++ b/tweepy/streaming.py
@@ -307,13 +307,13 @@ class Stream(object):
         self.url = '/%s/statuses/retweet.json' % STREAM_VERSION
         self._start(async)
 
-    def sample(self, async=False, language=None):
+    def sample(self, async=False, languages=None):
+        self.session.params = {'delimited': 'length'}
         if self.running:
             raise TweepError('Stream object already connected!')
-        self.url = '/%s/statuses/sample.json?delimited=length' % STREAM_VERSION
-        if language:
-            self.url += '&language=%s' % language
-            self.parameters['language'] = language
+        self.url = '/%s/statuses/sample.json' % STREAM_VERSION
+        if languages:
+            self.session.params['language'] = ','.join(map(str, languages))
         self._start(async)
 
     def filter(self, follow=None, track=None, async=False, locations=None,


### PR DESCRIPTION
I tried to fix sample method in streaming.py, so it uses Requests properly instead of old httplib syntax. I used firehose, filter and retweet as template for how code should be structured. It should now work properly with language parameter. This should fix #493 .
