### PR TITLE
Fix CursorIterator.next() for Python 3

### DIFF
--- a/tweepy/cursor.py
+++ b/tweepy/cursor.py
@@ -46,7 +46,7 @@ class BaseIterator(object):
         self.limit = 0
 
     def __next__(self):
-        self.next()
+        return self.next()
 
     def next(self):
         raise NotImplementedError


### PR DESCRIPTION
It was calling next, but returning None.

E.g. when iterating over returned tweets: `for tweet in Custor(...)` all objects were None.
