### PR TITLE
Modify ReadBuffer for Py3

### DIFF
--- a/tweepy/streaming.py
+++ b/tweepy/streaming.py
@@ -146,7 +146,7 @@ class ReadBuffer(object):
 
     def __init__(self, stream, chunk_size):
         self._stream = stream
-        self._buffer = ""
+        self._buffer = u""
         self._chunk_size = chunk_size
 
     def read_len(self, length):
@@ -154,7 +154,7 @@ class ReadBuffer(object):
             if len(self._buffer) >= length:
                 return self._pop(length)
             read_len = max(self._chunk_size, length - len(self._buffer))
-            self._buffer += self._stream.read(read_len)
+            self._buffer += self._stream.read(read_len).decode("ascii")
 
     def read_line(self, sep='\n'):
         start = 0
@@ -164,7 +164,7 @@ class ReadBuffer(object):
                 return self._pop(loc + len(sep))
             else:
                 start = len(self._buffer)
-            self._buffer += self._stream.read(self._chunk_size)
+            self._buffer += self._stream.read(self._chunk_size).decode("ascii")
 
     def _pop(self, length):
         r = self._buffer[:length]


### PR DESCRIPTION
In my Python 3.4.2 environment, UserStreaming did't work
because of an error of bytes-to-str conversion.

And also in my Python 2.7.8 environment, UserStreaming didn't work
because of UnicodeDecodeError.
To solve this problem, I added following to my code which imports tweepy.

```
import sys
reload(sys)
sys.setdefaultencoding('UTF-8')
```
