### PR TITLE
Updated requirements for pip 6.0+ to include a session

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #from distutils.core import setup
-import re
+import re, uuid
 from setuptools import setup, find_packages
 from pip.req import parse_requirements
 
@@ -14,7 +14,7 @@ if mo:
 else:
     raise RuntimeError("Unable to find version string in %s." % (VERSIONFILE,))
 
-install_reqs = parse_requirements('requirements.txt')
+install_reqs = parse_requirements('requirements.txt', session=uuid.uuid1())
 reqs = [str(req.req) for req in install_reqs]
 
 setup(name="tweepy",


### PR DESCRIPTION
The setup.py file does not create any errors now. The recent version required a session to be added to the parse requirements. A uuid was used for this and the package can now be installed properly.
