### PR TITLE
Add Documentation Page for streaming

### DIFF
--- a/docs/streaming_how_to.rst
+++ b/docs/streaming_how_to.rst
@@ -100,11 +100,11 @@ in a window of time, they will receive error 420.  The amount of time a client h
 will increase exponentially each time they make a failed attempt. 
 
 Tweepy's **Stream Listener** usefully passes error messages to an **on_error** stub. We can use **on_error** to 
-catch 420 errors and disconnect our stream.::
+catch 420 errors and disconnect our stream. ::
 
   class MyStreamListener(tweepy.StreamListener):
   
-  def on_error(self, status_code):
+      def on_error(self, status_code):
           if status_code == 420:
               #returning False in on_data disconnects the stream
               return False


### PR DESCRIPTION
I saw a request for better documentation of streaming on the forum.  I encountered this frustration as well a few months ago when I began working with Tweepy.  I was able to use the streaming api with Tweepy by reading the source code, but I wanted there to be a tutorial so that people could ramp up faster. 

Here is that tutorial. It is not super polished, but I think it's comparable in quality to the existing documentation. 

You should accept this pull since it's only useful documentation. 

Next steps would be to cover more of the on_ events, and to add an api reference for streaming.py.

Thanks, 
Groceryheist.
