### PR TITLE
Ensure join preparing follow param is operating on strings

### DIFF
--- a/tweepy/streaming.py
+++ b/tweepy/streaming.py
@@ -403,7 +403,7 @@ class Stream(object):
             raise TweepError('Stream object already connected!')
         self.url = '/%s/statuses/filter.json' % STREAM_VERSION
         if follow:
-            self.session.params['follow'] = u','.join(follow).encode(encoding)
+            self.session.params['follow'] = u','.join(map(str, follow)).encode(encoding)
         if track:
             self.session.params['track'] = u','.join(track).encode(encoding)
         if locations and len(locations) > 0:


### PR DESCRIPTION
The streamingwatcher.py example running in filter mode blows up because we end up joining on a list of integer user ids:
```python
Traceback (most recent call last):
  File "streamwatcher.py", line 91, in <module>
    main()
  File "streamwatcher.py", line 86, in main
    stream.filter(follow_list, track_list)
  File "build/bdist.linux-x86_64/egg/tweepy/streaming.py", line 406, in filter
TypeError: sequence item 0: expected string or Unicode, int found
```
See https://github.com/tweepy/examples/pull/9 which fixes the example's filter mode.