### PR TITLE
Allow multiple versions to be installed

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-requests==2.4.3
-requests_oauthlib==0.4.1
-six==1.7.3
+requests>=2.4.3
+requests_oauthlib>=0.4.1
+six>=1.7.3


### PR DESCRIPTION
After installing Tweepy, we end up having conflicting version requirements for `requests` in our code. Tweepy is forcing us to install `requests==2.4.3`.