### PR TITLE
Prevent infinite read loop in tweepy Stream

### DIFF
--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -162,12 +162,8 @@ class TweepyStreamReadBuffer(unittest.TestCase):
         # Mock it's read function so it can't be called too many times
         mock_read = MagicMock(side_effect=on_read)
 
-        # Add an _fp member to it, like a real requests.raw stream
-        mock_fp = MagicMock()
-        mock_fp.isclosed.return_value = True
-
         try:
-            with patch.multiple(stream, read=mock_read, _fp=mock_fp, create=True):
+            with patch.multiple(stream, create=True, read=mock_read, closed=True):
                 # Now the stream can't call 'read' more than call_limit times
                 # and it looks like a requests stream that is closed
                 buf = ReadBuffer(stream, 50)
@@ -175,7 +171,6 @@ class TweepyStreamReadBuffer(unittest.TestCase):
         except InfiniteLoopException:
             self.fail("ReadBuffer.read_line tried to loop infinitely.")
 
-        self.assertEqual(mock_fp.isclosed.call_count, 1)
         # The mocked function not have been called at all since the stream looks closed
         self.assertEqual(mock_read.call_count, 0)
 

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -133,6 +133,52 @@ class TweepyStreamReadBuffer(unittest.TestCase):
             self.assertEqual('24\n', buf.read_line())
             self.assertEqual('{id:23456, test:"blah"}\n', buf.read_len(24))
 
+    def test_read_empty_buffer(self):
+        """
+        Requests can be closed by twitter.
+        The ReadBuffer should not loop infinitely when this happens.
+        Instead it should return and let the outer _read_loop handle it.
+        """
+
+        # If the test fails, we are in danger of an infinite loop
+        # so we need to do some work to block that from happening
+        class InfiniteLoopException(Exception):
+            pass
+
+        self.called_count = 0
+        call_limit = 5
+        def on_read(chunk_size):
+            self.called_count += 1
+
+            if self.called_count > call_limit:
+                # we have failed
+                raise InfiniteLoopException("Oops, read() was called a bunch of times")
+
+            return ""
+
+        # Create a fake stream
+        stream = six.StringIO('')
+
+        # Mock it's read function so it can't be called too many times
+        mock_read = MagicMock(side_effect=on_read)
+
+        # Add an _fp member to it, like a real requests.raw stream
+        mock_fp = MagicMock()
+        mock_fp.isclosed.return_value = True
+
+        try:
+            with patch.multiple(stream, read=mock_read, _fp=mock_fp, create=True):
+                # Now the stream can't call 'read' more than call_limit times
+                # and it looks like a requests stream that is closed
+                buf = ReadBuffer(stream, 50)
+                buf.read_line("\n")
+        except InfiniteLoopException:
+            self.fail("ReadBuffer.read_line tried to loop infinitely.")
+
+        self.assertEqual(mock_fp.isclosed.call_count, 1)
+        # The mocked function not have been called at all since the stream looks closed
+        self.assertEqual(mock_read.call_count, 0)
+
 
 class TweepyStreamBackoffTests(unittest.TestCase):
     def setUp(self):

--- a/tweepy/streaming.py
+++ b/tweepy/streaming.py
@@ -154,7 +154,7 @@ class ReadBuffer(object):
         self._chunk_size = chunk_size
 
     def read_len(self, length):
-        while not self._stream._fp.isclosed():
+        while not self._stream.closed:
             if len(self._buffer) >= length:
                 return self._pop(length)
             read_len = max(self._chunk_size, length - len(self._buffer))
@@ -162,7 +162,7 @@ class ReadBuffer(object):
 
     def read_line(self, sep='\n'):
         start = 0
-        while not self._stream._fp.isclosed():
+        while not self._stream.closed:
             loc = self._buffer.find(sep, start)
             if loc >= 0:
                 return self._pop(loc + len(sep))
@@ -292,9 +292,9 @@ class Stream(object):
     def _read_loop(self, resp):
         buf = ReadBuffer(resp.raw, self.chunk_size)
 
-        while self.running and not resp.raw._fp.isclosed():
+        while self.running and not resp.raw.closed:
             length = 0
-            while not resp.raw._fp.isclosed():
+            while not resp.raw.closed:
                 line = buf.read_line().strip()
                 if not line:
                     self.listener.keep_alive()  # keep-alive new lines are expected
@@ -334,7 +334,7 @@ class Stream(object):
             #         self._data(next_status_obj.decode('utf-8'))
 
 
-        if resp.raw._fp.isclosed():
+        if resp.raw.closed:
             self.on_closed(resp)
 
     def _start(self, async):

--- a/tweepy/streaming.py
+++ b/tweepy/streaming.py
@@ -154,7 +154,7 @@ class ReadBuffer(object):
         self._chunk_size = chunk_size
 
     def read_len(self, length):
-        while True:
+        while not self._stream._fp.isclosed():
             if len(self._buffer) >= length:
                 return self._pop(length)
             read_len = max(self._chunk_size, length - len(self._buffer))
@@ -162,7 +162,7 @@ class ReadBuffer(object):
 
     def read_line(self, sep='\n'):
         start = 0
-        while True:
+        while not self._stream._fp.isclosed():
             loc = self._buffer.find(sep, start)
             if loc >= 0:
                 return self._pop(loc + len(sep))
@@ -292,9 +292,9 @@ class Stream(object):
     def _read_loop(self, resp):
         buf = ReadBuffer(resp.raw, self.chunk_size)
 
-        while self.running:
+        while self.running and not resp.raw._fp.isclosed():
             length = 0
-            while True:
+            while not resp.raw._fp.isclosed():
                 line = buf.read_line().strip()
                 if not line:
                     self.listener.keep_alive()  # keep-alive new lines are expected


### PR DESCRIPTION
I have noticed that my twitter streaming programs using tweepy (3.2.0 with requests 2.4.3) have been going into an infinite loop after a couple of days running. They seem to get stuck in the `ReadBuffer.read_line()` method. From breaking into it with a debugger, it looks like the underlying `raw` stream (in the `ReadBuffer` this is `self._stream`) is closed (`self._stream.closed` is True).

I am not certain how the stream gets closed, but probably there is a network glitch or Twitter just booted me randomly. I am surprised that no exception gets thrown from requests when you try to read from a closed response, but I don't know the library that well, so maybe this is intentional.

In the stream read loops in `stream.py`, there is currently only one check if the underlying stream has been "closed" (line 337), and it is actually *outside* the read loop. I looked back at the history of the file and found in #400 that *before* switching to the requests library, there were checks for `isclosed()` [all over the place](https://github.com/tweepy/tweepy/pull/400/files#diff-07400b70c336387bf35f0433991068f0L206), and after there was only the one.

Anyway, to try and prevent this from happening, I added checks to make sure the response stream is still open in the read loops within the `ReadBuffer` class, as well as in `Stream._read_loop()` method. I also updated line 337 at the bottom of the `_read_loop()` to use `resp.raw.closed` instead of `resp.raw._fp.closed()` since this seems like it is supposed to be private API.

I added a test in the `TweepyStreamReadBuffer` class that mocks a closed stream with no content available and then tries to call `read_line()` on it. Before I modified `stream.py` this test failed because `read_line()` looped infinitely. Now `read_line()` returns `None`, which hopefully is the desired result in this situation. Note that I had to do some extra work to block a true infinite loop inside the test, hence all the extra complexity there.

I don't know if I fixed this the best way, but the problem is pretty serious so I hope this can be fixed and released quickly. Thank you!