### PR TITLE
Update api.py

### DIFF
--- a/tweepy/api.py
+++ b/tweepy/api.py
@@ -1271,8 +1271,8 @@ class API(object):
             try:
                 if os.path.getsize(filename) > (max_size * 1024):
                     raise TweepError('File is too big, must be less than %skb.' % max_size)
-            except os.error:
-                raise TweepError('Unable to access file')
+            except os.error as e:
+                raise TweepError('Unable to access file: %s' % e.strerror)
 
             # build the mulitpart-formdata body
             fp = open(filename, 'rb')


### PR DESCRIPTION
Made catch statement error message more explicit for _pack_image. Now outputs  

tweepy.error.TweepError: Unable to access file: No such file or directory
