### PR TITLE
Fixes issue #570 - add "exception" when raising one

### DIFF
--- a/tweepy/streaming.py
+++ b/tweepy/streaming.py
@@ -283,7 +283,7 @@ class Stream(object):
         if exception:
             # call a handler first so that the exception can be logged.
             self.listener.on_exception(exception)
-            raise
+            raise exception
 
     def _data(self, data):
         if self.listener.on_data(data) is False:


### PR DESCRIPTION
This resolves an issue found here: https://github.com/tweepy/tweepy/issues/570

If an exception is thrown in the listener, the exception is not sent out currently and results in an error.