### PR TITLE
update_status: first positional argument should be 'status'

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -87,6 +87,17 @@ class TweepyAPITests(TweepyTestCase):
         deleted = self.api.destroy_status(id=update.id)
         self.assertEqual(deleted.id, update.id)
 
+    @tape.use_cassette('testupdateanddestroystatus.json')
+    def testupdateanddestroystatuswithoutkwarg(self):
+        # test update, passing text as a positional argument (#554)
+        text = tweet_text if use_replay else 'testing %i' % random.randint(0, 1000)
+        update = self.api.update_status(text)
+        self.assertEqual(update.text, text)
+
+        # test destroy
+        deleted = self.api.destroy_status(id=update.id)
+        self.assertEqual(deleted.id, update.id)
+
     @tape.use_cassette('testupdatestatuswithmedia.yaml', serializer='yaml')
     def testupdatestatuswithmedia(self):
         update = self.api.update_with_media('examples/banner.png', status=tweet_text)

--- a/tweepy/api.py
+++ b/tweepy/api.py
@@ -175,11 +175,12 @@ class API(object):
             allowed_param=['id']
         )
 
-    def update_status(self, media_ids=None, *args, **kwargs):
+    def update_status(self, *args, **kwargs):
         """ :reference: https://dev.twitter.com/rest/reference/post/statuses/update
             :allowed_param:'status', 'in_reply_to_status_id', 'lat', 'long', 'source', 'place_id', 'display_coordinates', 'media_ids'
         """
         post_data = {}
+        media_ids = kwargs.pop("media_ids", None)
         if media_ids is not None:
             post_data["media_ids"] = list_to_csv(media_ids)
         


### PR DESCRIPTION
Passing the tweet text as the lone positional argument to update_status:

     api.update_status(u'Hi mum!')

is suggested in much documentation and in several tests, but f99b1da
introduced media_ids as the first argument, breaking this API.

This change will break anyone who uses tweepy >= 3.2 and assumes they
can pass media_ids as the first positional; but I expect that to be a
much smaller set than people who have followed the example in the docs,
who find their application mysteriously fails to post tweets after
upgrading tweepy.

Fixes #554 

(I haven't successfully run the tests, I'm hoping Travis will do that for me and save me the hassle of working out the token situation.)