### PR TITLE
adds additional parameters in friends/list API

### DIFF
--- a/tweepy/api.py
+++ b/tweepy/api.py
@@ -182,7 +182,7 @@ class API(object):
         post_data = {}
         if media_ids is not None:
             post_data["media_ids"] = list_to_csv(media_ids)
-        
+
         return bind_api(
             api=self,
             path='/statuses/update.json',
@@ -528,13 +528,14 @@ class API(object):
     @property
     def friends(self):
         """ :reference: https://dev.twitter.com/rest/reference/get/friends/list
-            :allowed_param:'id', 'user_id', 'screen_name', 'cursor'
+            :allowed_param:'id', 'user_id', 'screen_name', 'cursor', 'count', 'skip_status', 'include_user_entities'
         """
         return bind_api(
             api=self,
             path='/friends/list.json',
             payload_type='user', payload_list=True,
-            allowed_param=['id', 'user_id', 'screen_name', 'cursor']
+            allowed_param=['id', 'user_id', 'screen_name', 'cursor', 'count',
+                           'skip_status', 'include_user_entities']
         )
 
     @property


### PR DESCRIPTION
Twitter added several additional parameters(count, skip_status, include_user_entities) in friends/list API.

Refer to https://dev.twitter.com/rest/reference/get/friends/list
