### PR TITLE
Solution for the issue #576. Add a return statement at the end of read_line method.

### DIFF
--- a/tweepy/streaming.py
+++ b/tweepy/streaming.py
@@ -169,6 +169,7 @@ class ReadBuffer(object):
             else:
                 start = len(self._buffer)
             self._buffer += self._stream.read(self._chunk_size).decode("ascii")
+        return '0'  # For situations in which the stream closes but the separator couldn't be found.
 
     def _pop(self, length):
         r = self._buffer[:length]


### PR DESCRIPTION
As a way to to solve the issue #576, I propose to add a return statement at the end of the read_line method so the method returns a string with content 0 in situations in which the stream closes but the separator couldn't be found.
