### PR TITLE
Added RateLimitError for easily working with the rate limit.

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -34,3 +34,4 @@ Mike (mikeandmore)
 Kohei YOSHIDA
 Mark Smith (@judy2k)
 Steven Skoczen (@skoczen)
+Samuel (@obskyr)

--- a/tweepy/__init__.py
+++ b/tweepy/__init__.py
@@ -10,7 +10,7 @@ __author__ = 'Joshua Roesslein'
 __license__ = 'MIT'
 
 from tweepy.models import Status, User, DirectMessage, Friendship, SavedSearch, SearchResults, ModelFactory, Category
-from tweepy.error import TweepError
+from tweepy.error import TweepError, RateLimitError
 from tweepy.api import API
 from tweepy.cache import Cache, MemoryCache, FileCache
 from tweepy.auth import OAuthHandler, AppAuthHandler

--- a/tweepy/binder.py
+++ b/tweepy/binder.py
@@ -12,7 +12,7 @@ import requests
 
 import logging
 
-from tweepy.error import TweepError
+from tweepy.error import TweepError, RateLimitError, is_rate_limit_error_message
 from tweepy.utils import convert_to_utf8_str
 from tweepy.models import Model
 
@@ -220,7 +220,11 @@ def bind_api(**config):
                     error_msg = self.parser.parse_error(resp.text)
                 except Exception:
                     error_msg = "Twitter error response: status code = %s" % resp.status_code
-                raise TweepError(error_msg, resp)
+
+                if is_rate_limit_error_message(error_msg):
+                    raise RateLimitError(error_msg, resp)
+                else:
+                    raise TweepError(error_msg, resp)
 
             # Parse the response payload
             result = self.parser.parse(self, resp.text)

--- a/tweepy/error.py
+++ b/tweepy/error.py
@@ -6,7 +6,6 @@ from __future__ import print_function
 
 import six
 
-
 class TweepError(Exception):
     """Tweepy exception"""
 
@@ -17,3 +16,16 @@ class TweepError(Exception):
 
     def __str__(self):
         return self.reason
+
+def is_rate_limit_error_message(message):
+    """Check if the supplied error message belongs to a rate limit error."""
+    return isinstance(message, list) \
+        and len(message) > 0 \
+        and 'code' in message[0] \
+        and message[0]['code'] == 88
+
+class RateLimitError(TweepError):
+    """Exception for Tweepy hitting the rate limit."""
+    # RateLimitError has the exact same properties and inner workings
+    # as TweepError for backwards compatibility reasons.
+    pass


### PR DESCRIPTION
For full details on this issue and how it's implemented, see issue #600.

With this pull request merged, Tweepy raises a `tweepy.error.RateLimitError` (can be accessed as `tweepy.RateLimitError` too) whenever an API operation hits the rate limit.

The great thing about this is that this will break *no* existing code! It's fully backwards compatible. `RateLimitError` inherits from `TweepError`, so catching `TweepError`s will still catch `RateLimitError`s. They also work the exact same way, so existing code dealing with rate limit error identification (such as the code shown in #600) will still work fine - as will any code accessing any property of the error.

This makes working with the rate limit a whole lot easier and dev-friendly. If there are any concerns at all, I'd be happy to address them.
