### PR TITLE
Change raise in streaming.py to raise exception

### DIFF
--- a/tweepy/streaming.py
+++ b/tweepy/streaming.py
@@ -283,7 +283,7 @@ class Stream(object):
         if exception:
             # call a handler first so that the exception can be logged.
             self.listener.on_exception(exception)
-            raise
+            raise exception
 
     def _data(self, data):
         if self.listener.on_data(data) is False:


### PR DESCRIPTION
Saw [this SO thread](http://stackoverflow.com/a/28871066) when I had an issue, and didn't look like anyone had gone to fix it yet. 

This prevents the ```RuntimeError: No active exception to reraise``` error when using Streaming.py (in theory).

To be clear, this isn't my fix, just something I saw someone suggest on SO that appears to have fixed it on my machine. With the fix, the exception actually gets raised, and gives you a more meaningful error message.
