### PR TITLE
Added full params to .friends()

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -174,7 +174,7 @@ User methods
    :rtype: :class:`User` object
 
 
-.. method::API.friends([id/user_id/screen_name], [cursor])
+.. method::API.friends([id/user_id/screen_name], [cursor], [skip_status], [include_user_entities])
 
    Returns an user's friends ordered in which they were added 100 at a time. If no user is specified it defaults to the authenticated user.
 
@@ -182,6 +182,8 @@ User methods
    :param user_id: |user_id|
    :param screen_name: |screen_name|
    :param cursor: |cursor|
+   :param skip_status: |skip_status|
+   :param include_user_entities: |include_user_entities|
    :rtype: list of :class:`User` objects
 
 

--- a/tweepy/api.py
+++ b/tweepy/api.py
@@ -528,13 +528,13 @@ class API(object):
     @property
     def friends(self):
         """ :reference: https://dev.twitter.com/rest/reference/get/friends/list
-            :allowed_param:'id', 'user_id', 'screen_name', 'cursor'
+            :allowed_param:'id', 'user_id', 'screen_name', 'cursor', 'skip_status', 'include_user_entities'
         """
         return bind_api(
             api=self,
             path='/friends/list.json',
             payload_type='user', payload_list=True,
-            allowed_param=['id', 'user_id', 'screen_name', 'cursor']
+            allowed_param=['id', 'user_id', 'screen_name', 'cursor', 'skip_status', 'include_user_entities']
         )
 
     @property


### PR DESCRIPTION
Added the 'skip_status' and 'include_user_entities' to the .friends() method. This now aligns with the latest options available in the Twitter API for [the method call](https://dev.twitter.com/rest/reference/get/friends/list).

These two options allow you to toggle how much information you want returned from the API.

```python
friends = api.friends()
# friends is now a list of users including their latest status

friends = api.friends(skip_status=False)
# friends is now a list of users without their latest status
```

The API documentation file was also updated to reflect these changes.

**Note**: that ```include_user_entities``` currently doesn't appear to have an effect on the what data is returned.

