### PR TITLE
Parse quoted_status dict to Status object

### DIFF
--- a/tweepy/models.py
+++ b/tweepy/models.py
@@ -93,6 +93,8 @@ class Status(Model):
                     setattr(status, 'source_url', None)
             elif k == 'retweeted_status':
                 setattr(status, k, Status.parse(api, v))
+            elif k == 'quoted_status':
+                setattr(status, k, Status.parse(api, v))
             elif k == 'place':
                 if v is not None:
                     setattr(status, k, Place.parse(api, v))


### PR DESCRIPTION
The quoted_status property of a Tweet is not currently being parsed but it is stored as a simple dict.

I think it would better to be consistent and convert it to a Status object just like retweeted_status.
