### PR TITLE
Fix streaming.py to run on BOTH PY3 and py2

### DIFF
--- a/tweepy/streaming.py
+++ b/tweepy/streaming.py
@@ -46,7 +46,10 @@ class StreamListener(object):
         Override this method if you wish to manually handle
         the stream data. Return False to stop stream and close connection.
         """
-        data = json.loads(raw_data)
+        if six.PY2:
+          data = json.loads(raw_data)
+        elif six.PY3:
+          data = json.loads(raw_data.decode('ascii'))
 
         if 'in_reply_to_status_id' in data:
             status = Status.parse(self.api, data)
@@ -150,7 +153,7 @@ class ReadBuffer(object):
 
     def __init__(self, stream, chunk_size):
         self._stream = stream
-        self._buffer = ''
+        self._buffer = six.b('')
         self._chunk_size = chunk_size
 
     def read_len(self, length):
@@ -160,7 +163,7 @@ class ReadBuffer(object):
             read_len = max(self._chunk_size, length - len(self._buffer))
             self._buffer += self._stream.read(read_len)
 
-    def read_line(self, sep='\n'):
+    def read_line(self, sep=six.b('\n')):
         start = 0
         while not self._stream.closed:
             loc = self._buffer.find(sep, start)


### PR DESCRIPTION
Previously I requested to merge this commit (https://github.com/tweepy/tweepy/commit/48d2744d7b948f166ebf67796d7fec4c278688a1).
Indeed this is not a good solution, but after this commit (https://github.com/tweepy/tweepy/commit/2bbef250ffaab8297c6b35e3225bfef28a5e65e5), this function may have NOT been able to use with Python 3.

HAVE YOU EVER TESTED WITH PYTHON 3 ENVIRONMENT????

Now then, I made some fixes to enable the code to be used with both py3 and py2.
I tested with this code (https://gist.github.com/7kry/27459f70cfc3745fe068/69a088ddaa670d7f5f8938c2b4cff59158dd7e68).
Please consider to merge.