### PR TITLE
Python 3.5 is out

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,3 @@ deploy:
 
 matrix:
   fast_finish: true
-  allow_failures:
-    - python: '2.6'
-    - python: '3.3'
-    - python: '3.5'

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,11 @@ sudo: false
 language: python
 
 python:
+- '2.6'
 - '2.7'
+- '3.3'
 - '3.4'
+- '3.5'
 
 env:
   global:
@@ -55,3 +58,10 @@ deploy:
   on:
     repo: tweepy/tweepy
     branch: release
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - python: '2.6'
+    - python: '3.3'
+    - python: '3.5'

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Github and install it manually:
     cd tweepy
     python setup.py install
 
-Python 2.6 and 2.7, 3.3 & 3.4 are supported.
+Python 2.6 and 2.7, 3.3, 3.4  & 3.5 are supported.
 
 Documentation
 -------------

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27, py33, py34
+envlist = py26, py27, py33, py34, py35
 
 [base]
 deps =


### PR DESCRIPTION
So test it on Travis CI.

Travis CI also has Python 2.6 and 3.3, so because Tweepy supports them it's a good idea to test them too.