### PR TITLE
Documented exceptions and how to handle them

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -777,3 +777,29 @@ Geo Methods
    Given *id* of a place, provide more details about that place.
 
    :param id: Valid Twitter ID of a location.
+
+:mod:`tweepy.error` --- Exceptions
+==================================
+
+The exceptions are available in the ``tweepy`` module directly,
+which means ``tweepy.error`` itself does not need to be imported. For
+example, ``tweepy.error.TweepError`` is available as ``tweepy.TweepError``.
+
+.. exception:: TweepError
+   
+   The main exception Tweepy uses. Is raised for a number of things.
+   
+   When a ``TweepError`` is raised due to an error Twitter responded with,
+   the error code (`as described in the API documentation
+   <https://dev.twitter.com/overview/api/response-codes>`_) can be accessed
+   at ``TweepError.message[0]['code']``. Note, however, that ``TweepError``\ s
+   also may be raised with other things as message (for example plain
+   error reason strings).
+
+.. exception:: RateLimitError
+   
+   Is raised when an API method fails due to hitting Twitter's rate
+   limit. Makes for easy handling of the rate limit specifically.
+   
+   Inherits from :exc:`TweepError`, so ``except TweepError`` will
+   catch a ``RateLimitError`` too.

--- a/docs/code_snippet.rst
+++ b/docs/code_snippet.rst
@@ -51,3 +51,29 @@ This snippet will follow every follower of the authenticated user.
 
    for follower in tweepy.Cursor(api.followers).items():
        follower.follow()
+
+Handling the rate limit using cursors
+=====================================
+   
+Since cursors raise ``RateLimitError``\ s in their ``next()`` method,
+handling them can be done by wrapping the cursor in an iterator.
+   
+Running this snippet will print all users you follow that themselves follow
+less than 300 people total - to exclude obvious spambots, for example - and
+will wait for 15 minutes each time it hits the rate limit.
+   
+.. code-block :: python
+   
+   # In this example, the handler is time.sleep(15 * 60),
+   # but you can of course handle it in any way you want.
+   
+   def limit_handled(cursor):
+       while True:
+           try:
+               yield cursor.next()
+           except tweepy.RateLimitError:
+               time.sleep(15 * 60)
+   
+   for follower in limit_handled(tweepy.Cursor(api.followers).items()):
+       if follower.friends_count < 300:
+           print follower.screen_name


### PR DESCRIPTION
The fact that `TweepError` and `RateLimitError` aren't really documented anywhere (especially the latter) is a bit of a problem.

This pull requests adds the exceptions to the docs, and adds a code snippet for working with the rate limit while using cursors.