### PR TITLE
Fix duplicate raise in auth.py

### DIFF
--- a/tweepy/auth.py
+++ b/tweepy/auth.py
@@ -85,7 +85,6 @@ class OAuthHandler(AuthHandler):
             self.request_token = self._get_request_token(access_type=access_type)
             return self.oauth.authorization_url(url)
         except Exception as e:
-            raise
             raise TweepError(e)
 
     def get_access_token(self, verifier=None):


### PR DESCRIPTION
Hi,

I'm not sure, but I think this is a bug. So I removed this duplicate raise in auth.py

```python
    def get_authorization_url(self,
                              signin_with_twitter=False,
                              access_type=None):
        """Get the authorization URL to redirect the user"""
        try:
            if signin_with_twitter:
                url = self._get_oauth_url('authenticate')
                if access_type:
                    logging.warning(WARNING_MESSAGE)
            else:
                url = self._get_oauth_url('authorize')
            self.request_token = self._get_request_token(access_type=access_type)
            return self.oauth.authorization_url(url)
        except Exception as e:
            raise
            raise TweepError(e)
```

:)