### PR TITLE
Video upload

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -87,6 +87,17 @@ class TweepyAPITests(TweepyTestCase):
         deleted = self.api.destroy_status(id=update.id)
         self.assertEqual(deleted.id, update.id)
 
+    @tape.use_cassette('testupdateanddestroystatus.json')
+    def testupdateanddestroystatuswithoutkwarg(self):
+        # test update, passing text as a positional argument (#554)
+        text = tweet_text if use_replay else 'testing %i' % random.randint(0, 1000)
+        update = self.api.update_status(text)
+        self.assertEqual(update.text, text)
+
+        # test destroy
+        deleted = self.api.destroy_status(id=update.id)
+        self.assertEqual(deleted.id, update.id)
+
     @tape.use_cassette('testupdatestatuswithmedia.yaml', serializer='yaml')
     def testupdatestatuswithmedia(self):
         update = self.api.update_with_media('examples/banner.png', status=tweet_text)

--- a/tweepy/api.py
+++ b/tweepy/api.py
@@ -262,7 +262,11 @@ class API(object):
 
         # If a media ID has been generated, we can send the file
         if media_info.media_id:
-            chunk_size = kwargs.pop('chunk_size', 4096)
+            # default chunk size is 1MB, can be overridden with keyword argument.
+            # minimum chunk size is 16K, which keeps the maximum number of chunks under 999
+            chunk_size = kwargs.pop('chunk_size', 1024 * 1024)
+            chunk_size = max(chunk_size, 16 * 2014)
+
             fsize = os.path.getsize(filename)
             nloops = int(fsize / chunk_size) + (1 if fsize % chunk_size > 0 else 0)
             for i in range(nloops):

--- a/tweepy/api.py
+++ b/tweepy/api.py
@@ -208,15 +208,21 @@ class API(object):
             :reference https://dev.twitter.com/rest/reference/post/media/upload-chunked
             :allowed_param:
         """
+        f = kwargs.pop('file', None)
 
         mime, _ = mimetypes.guess_type(filename)
-        size = os.path.getsize(filename)
+        try:
+            size = os.path.getsize(filename)
+        except OSError:
+            f.seek(0, 2)
+            size = f.tell()
+            f.seek(0)
 
         if mime in IMAGE_MIMETYPES and size < self.max_size_standard:
-            return self.image_upload(filename, *args, **kwargs)
+            return self.image_upload(filename, f=f, *args, **kwargs)
 
         elif mime in CHUNKED_MIMETYPES:
-            return self.upload_chunked(filename, *args, **kwargs)
+            return self.upload_chunked(filename, f=f, *args, **kwargs)
 
         else:
             raise TweepError("Can't upload media with mime type %s" % mime)
@@ -1469,7 +1475,7 @@ class API(object):
         if file_type is None:
             raise TweepError('Could not determine file type')
 
-        if file_type not in ['video/mp4']:
+        if file_type not in CHUNKED_MIMETYPES:
             raise TweepError('Invalid file type for video: %s' % file_type)
 
         BOUNDARY = b'Tw3ePy'

--- a/tweepy/api.py
+++ b/tweepy/api.py
@@ -8,10 +8,11 @@ import os
 import mimetypes
 
 import six
+import urllib
 
 from tweepy.binder import bind_api
 from tweepy.error import TweepError
-from tweepy.parsers import ModelParser, Parser
+from tweepy.parsers import ModelParser, Parser, RawParser
 from tweepy.utils import list_to_csv
 
 
@@ -210,6 +211,60 @@ class API(object):
             require_auth=True,
             upload_api=True
         )(*args, **kwargs)
+
+    def video_upload(self, filename, *args, **kwargs):
+        """ :reference https://dev.twitter.com/rest/reference/post/media/upload-chunked
+            :allowed_param:
+        """
+        f = kwargs.pop('file', None)
+        # Initialize upload (Twitter cannot handle videos > 15 MB)
+        headers, post_data, fp = API._chunk_video('init', filename, 15360, form_field='media', f=f)
+        kwargs.update({ 'headers': headers, 'post_data': post_data })
+
+        # Send the INIT request
+        media_info = bind_api(
+            api=self,
+            path='/media/upload.json',
+            method='POST',
+            payload_type='media',
+            allowed_param=[],
+            require_auth=True,
+            upload_api=True
+        )(*args, **kwargs)
+
+        # If a media ID has been generated, we can send the file
+        if media_info.media_id:
+            chunk_size = kwargs.pop('chunk_size', 4096)
+            fsize = os.path.getsize(filename)
+            nloops = int(fsize / chunk_size) + (1 if fsize % chunk_size > 0 else 0)
+            for i in range(nloops):
+                headers, post_data, fp = API._chunk_video('append', filename, 15360, chunk_size=chunk_size, f=fp, media_id=media_info.media_id, segment_index=i)
+                kwargs.update({ 'headers': headers, 'post_data': post_data, 'parser': RawParser() })
+                # The APPEND command returns an empty response body
+                bind_api(
+                    api=self,
+                    path='/media/upload.json',
+                    method='POST',
+                    payload_type='media',
+                    allowed_param=[],
+                    require_auth=True,
+                    upload_api=True
+                )(*args, **kwargs)
+            # When all chunks have been sent, we can finalize.
+            headers, post_data, fp = API._chunk_video('finalize', filename, 15360, media_id=media_info.media_id)
+            kwargs.update({ 'headers': headers, 'post_data': post_data })
+            # The FINALIZE command returns media information
+            return bind_api(
+                api=self,
+                path='/media/upload.json',
+                method='POST',
+                payload_type='media',
+                allowed_param=[],
+                require_auth=True,
+                upload_api=True
+            )(*args, **kwargs)
+        else:
+            return media_info
 
     def update_with_media(self, filename, *args, **kwargs):
         """ :reference: https://dev.twitter.com/rest/reference/post/statuses/update_with_media
@@ -1346,3 +1401,94 @@ class API(object):
         }
 
         return headers, body
+
+    @staticmethod
+    def _chunk_video(command, filename, max_size, form_field="media", chunk_size=4096, f=None, media_id=None, segment_index=0):
+        fp = None
+        if command == 'init':
+            if f is None:
+                file_size = os.path.getsize(filename)
+                try:
+                    if file_size > (max_size * 1024):
+                        raise TweepError('File is too big, must be less than %skb.' % max_size)
+                except os.error as e:
+                    raise TweepError('Unable to access file: %s' % e.strerror)
+
+                # build the mulitpart-formdata body
+                fp = open(filename, 'rb')
+            else:
+                f.seek(0, 2)  # Seek to end of file
+                file_size = f.tell()
+                if file_size > (max_size * 1024):
+                    raise TweepError('File is too big, must be less than %skb.' % max_size)
+                f.seek(0)  # Reset to beginning of file
+                fp = f
+        elif command != 'finalize':
+            if f is not None:
+                fp = f
+            else:
+                raise TweepError('File input for APPEND is mandatory.')
+
+        # video must be mp4
+        file_type = mimetypes.guess_type(filename)
+        if file_type is None:
+            raise TweepError('Could not determine file type')
+        file_type = file_type[0]
+        if file_type not in ['video/mp4']:
+            raise TweepError('Invalid file type for video: %s' % file_type)
+
+        BOUNDARY = b'Tw3ePy'
+        body = list()
+        if command == 'init':
+            body.append(
+                urllib.urlencode({
+                    'command': 'INIT',
+                    'media_type': file_type,
+                    'total_bytes': file_size
+                })
+            )
+            headers = {
+                'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8'
+            }
+        elif command == 'append':
+            if media_id is None:
+                raise TweepError('Media ID is required for APPEND command.')
+            body.append(b'--' + BOUNDARY)
+            body.append('Content-Disposition: form-data; name="command"'.encode('utf-8'))
+            body.append(b'')
+            body.append(b'APPEND')
+            body.append(b'--' + BOUNDARY)
+            body.append('Content-Disposition: form-data; name="media_id"'.encode('utf-8'))
+            body.append(b'')
+            body.append(str(media_id).encode('utf-8'))
+            body.append(b'--' + BOUNDARY)
+            body.append('Content-Disposition: form-data; name="segment_index"'.encode('utf-8'))
+            body.append(b'')
+            body.append(str(segment_index).encode('utf-8'))
+            body.append(b'--' + BOUNDARY)
+            body.append('Content-Disposition: form-data; name="{0}"; filename="{1}"'.format(form_field, os.path.basename(filename)).encode('utf-8'))
+            body.append('Content-Type: {0}'.format(file_type).encode('utf-8'))
+            body.append(b'')
+            body.append(fp.read(chunk_size))
+            body.append(b'--' + BOUNDARY + b'--')
+            headers = {
+                'Content-Type': 'multipart/form-data; boundary=Tw3ePy'
+            }
+        elif command == 'finalize':
+            if media_id is None:
+                raise TweepError('Media ID is required for FINALIZE command.')
+            body.append(
+                urllib.urlencode({
+                    'command': 'FINALIZE',
+                    'media_id': media_id
+                })
+            )
+            headers = {
+                'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8'
+            }
+
+        body = b'\r\n'.join(body)
+        # build headers
+        headers['Content-Length'] = str(len(body))
+
+        return headers, body, fp

--- a/tweepy/api.py
+++ b/tweepy/api.py
@@ -175,11 +175,12 @@ class API(object):
             allowed_param=['id']
         )
 
-    def update_status(self, media_ids=None, *args, **kwargs):
+    def update_status(self, *args, **kwargs):
         """ :reference: https://dev.twitter.com/rest/reference/post/statuses/update
             :allowed_param:'status', 'in_reply_to_status_id', 'lat', 'long', 'source', 'place_id', 'display_coordinates', 'media_ids'
         """
         post_data = {}
+        media_ids = kwargs.pop("media_ids", None)
         if media_ids is not None:
             post_data["media_ids"] = list_to_csv(media_ids)
 

--- a/tweepy/api.py
+++ b/tweepy/api.py
@@ -1399,10 +1399,11 @@ class API(object):
             fp = f
 
         # image must be gif, jpeg, or png
-        file_type = mimetypes.guess_type(filename)
+        file_type, _ = mimetypes.guess_type(filename)
+
         if file_type is None:
             raise TweepError('Could not determine file type')
-        file_type = file_type[0]
+
         if file_type not in IMAGE_MIMETYPES:
             raise TweepError('Invalid file type for image: %s' % file_type)
 
@@ -1459,10 +1460,11 @@ class API(object):
                 raise TweepError('File input for APPEND is mandatory.')
 
         # video must be mp4
-        file_type = mimetypes.guess_type(filename)
+        file_type, _ = mimetypes.guess_type(filename)
+
         if file_type is None:
             raise TweepError('Could not determine file type')
-        file_type = file_type[0]
+
         if file_type not in ['video/mp4']:
             raise TweepError('Invalid file type for video: %s' % file_type)
 

--- a/tweepy/api.py
+++ b/tweepy/api.py
@@ -8,16 +8,25 @@ import os
 import mimetypes
 
 import six
-import urllib
+
+if six.PY2:
+    from urllib import urlencode
+elif six.PY3:
+    from urllib.parse import urlencode
 
 from tweepy.binder import bind_api
 from tweepy.error import TweepError
 from tweepy.parsers import ModelParser, Parser, RawParser
 from tweepy.utils import list_to_csv
 
+IMAGE_MIMETYPES = ('image/gif', 'image/jpeg', 'image/png', 'image/webp')
+CHUNKED_MIMETYPES = ('image/gif', 'image/jpeg', 'image/png', 'image/webp', 'video/mp4')
 
 class API(object):
     """Twitter API"""
+
+    max_size_standard = 5120  # standard uploads must be less then 5 MB
+    max_size_chunked = 15360  # chunked uploads must be less than 15 MB
 
     def __init__(self, auth_handler=None,
                  host='api.twitter.com', search_host='search.twitter.com',
@@ -196,10 +205,28 @@ class API(object):
 
     def media_upload(self, filename, *args, **kwargs):
         """ :reference: https://dev.twitter.com/rest/reference/post/media/upload
+            :reference https://dev.twitter.com/rest/reference/post/media/upload-chunked
+            :allowed_param:
+        """
+
+        mime, _ = mimetypes.guess_type(filename)
+        size = os.path.getsize(filename)
+
+        if mime in IMAGE_MIMETYPES and size < self.max_size_standard:
+            return self.image_upload(filename, *args, **kwargs)
+
+        elif mime in CHUNKED_MIMETYPES:
+            return self.upload_chunked(filename, *args, **kwargs)
+
+        else:
+            raise TweepError("Can't upload media with mime type %s" % mime)
+
+    def image_upload(self, filename, *args, **kwargs):
+        """ :reference: https://dev.twitter.com/rest/reference/post/media/upload
             :allowed_param:
         """
         f = kwargs.pop('file', None)
-        headers, post_data = API._pack_image(filename, 3072, form_field='media', f=f)
+        headers, post_data = API._pack_image(filename, self.max_size_standard, form_field='media', f=f)
         kwargs.update({'headers': headers, 'post_data': post_data})
 
         return bind_api(
@@ -212,13 +239,14 @@ class API(object):
             upload_api=True
         )(*args, **kwargs)
 
-    def video_upload(self, filename, *args, **kwargs):
+    def upload_chunked(self, filename, *args, **kwargs):
         """ :reference https://dev.twitter.com/rest/reference/post/media/upload-chunked
             :allowed_param:
         """
         f = kwargs.pop('file', None)
+
         # Initialize upload (Twitter cannot handle videos > 15 MB)
-        headers, post_data, fp = API._chunk_video('init', filename, 15360, form_field='media', f=f)
+        headers, post_data, fp = API._chunk_media('init', filename, self.max_size_chunked, form_field='media', f=f)
         kwargs.update({ 'headers': headers, 'post_data': post_data })
 
         # Send the INIT request
@@ -238,7 +266,7 @@ class API(object):
             fsize = os.path.getsize(filename)
             nloops = int(fsize / chunk_size) + (1 if fsize % chunk_size > 0 else 0)
             for i in range(nloops):
-                headers, post_data, fp = API._chunk_video('append', filename, 15360, chunk_size=chunk_size, f=fp, media_id=media_info.media_id, segment_index=i)
+                headers, post_data, fp = API._chunk_media('append', filename, self.max_size_chunked, chunk_size=chunk_size, f=fp, media_id=media_info.media_id, segment_index=i)
                 kwargs.update({ 'headers': headers, 'post_data': post_data, 'parser': RawParser() })
                 # The APPEND command returns an empty response body
                 bind_api(
@@ -251,8 +279,9 @@ class API(object):
                     upload_api=True
                 )(*args, **kwargs)
             # When all chunks have been sent, we can finalize.
-            headers, post_data, fp = API._chunk_video('finalize', filename, 15360, media_id=media_info.media_id)
-            kwargs.update({ 'headers': headers, 'post_data': post_data })
+            headers, post_data, fp = API._chunk_media('finalize', filename, self.max_size_chunked, media_id=media_info.media_id)
+            kwargs = {'headers': headers, 'post_data': post_data}
+
             # The FINALIZE command returns media information
             return bind_api(
                 api=self,
@@ -1352,7 +1381,7 @@ class API(object):
     @staticmethod
     def _pack_image(filename, max_size, form_field="image", f=None):
         """Pack image from file into multipart-formdata post body"""
-        # image must be less than 700kb in size
+        # image must be less than 5MB in size
         if f is None:
             try:
                 if os.path.getsize(filename) > (max_size * 1024):
@@ -1374,7 +1403,7 @@ class API(object):
         if file_type is None:
             raise TweepError('Could not determine file type')
         file_type = file_type[0]
-        if file_type not in ['image/gif', 'image/jpeg', 'image/png']:
+        if file_type not in IMAGE_MIMETYPES:
             raise TweepError('Invalid file type for image: %s' % file_type)
 
         if isinstance(filename, six.text_type):
@@ -1403,7 +1432,7 @@ class API(object):
         return headers, body
 
     @staticmethod
-    def _chunk_video(command, filename, max_size, form_field="media", chunk_size=4096, f=None, media_id=None, segment_index=0):
+    def _chunk_media(command, filename, max_size, form_field="media", chunk_size=4096, f=None, media_id=None, segment_index=0):
         fp = None
         if command == 'init':
             if f is None:
@@ -1441,11 +1470,11 @@ class API(object):
         body = list()
         if command == 'init':
             body.append(
-                urllib.urlencode({
+                urlencode({
                     'command': 'INIT',
                     'media_type': file_type,
                     'total_bytes': file_size
-                })
+                }).encode('utf-8')
             )
             headers = {
                 'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8'
@@ -1478,10 +1507,10 @@ class API(object):
             if media_id is None:
                 raise TweepError('Media ID is required for FINALIZE command.')
             body.append(
-                urllib.urlencode({
+                urlencode({
                     'command': 'FINALIZE',
                     'media_id': media_id
-                })
+                }).encode('utf-8')
             )
             headers = {
                 'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8'

--- a/tweepy/binder.py
+++ b/tweepy/binder.py
@@ -179,19 +179,20 @@ def bind_api(**config):
 
                 # Execute request
                 try:
-                    resp = self.session.request(self.method,
-                                                full_url,
-                                                data=self.post_data,
-                                                timeout=self.api.timeout,
-                                                auth=auth,
-                                                proxies=self.api.proxy)
-                except UnicodeEncodeError:
-                    resp = self.session.request(self.method,
-                                                full_url,
-                                                data=self.post_data.decode('utf-8'),
-                                                timeout=self.api.timeout,
-                                                auth=auth,
-                                                proxies=self.api.proxy)
+                    try:
+                        resp = self.session.request(self.method,
+                                                    full_url,
+                                                    data=self.post_data,
+                                                    timeout=self.api.timeout,
+                                                    auth=auth,
+                                                    proxies=self.api.proxy)
+                    except UnicodeEncodeError:
+                        resp = self.session.request(self.method,
+                                                    full_url,
+                                                    data=self.post_data.decode('utf-8'),
+                                                    timeout=self.api.timeout,
+                                                    auth=auth,
+                                                    proxies=self.api.proxy)
                 except Exception as e:
                     raise TweepError('Failed to send request: %s' % e)
                 rem_calls = resp.headers.get('x-rate-limit-remaining')

--- a/tweepy/binder.py
+++ b/tweepy/binder.py
@@ -185,6 +185,13 @@ def bind_api(**config):
                                                 timeout=self.api.timeout,
                                                 auth=auth,
                                                 proxies=self.api.proxy)
+                except UnicodeEncodeError:
+                    resp = self.session.request(self.method,
+                                                full_url,
+                                                data=self.post_data.decode('utf-8'),
+                                                timeout=self.api.timeout,
+                                                auth=auth,
+                                                proxies=self.api.proxy)
                 except Exception as e:
                     raise TweepError('Failed to send request: %s' % e)
                 rem_calls = resp.headers.get('x-rate-limit-remaining')


### PR DESCRIPTION
As I mentioned in #655, this is an alternate way of adding video upload. The media_upload method gets a conditional, with smaller images routed to 'normal' upload, and larger images and videos chunked upload. I also moved upload limits to a class variable, to make them easier to change if the need arises.

This also fixes from unicode errors as flagged by @jeremylow.
