### PR TITLE
stream: Preserve re-raised exception traceback

### DIFF
--- a/tweepy/streaming.py
+++ b/tweepy/streaming.py
@@ -291,7 +291,7 @@ class Stream(object):
         if exception:
             # call a handler first so that the exception can be logged.
             self.listener.on_exception(exception)
-            raise exception
+            raise
 
     def _data(self, data):
         if self.listener.on_data(data) is False:


### PR DESCRIPTION
Using a bare `raise` will automatically raise the last caught exception in a way that preserves the original traceback. See the answers to this SO question for more details: http://stackoverflow.com/questions/4825234/exception-traceback-is-hidden-if-not-re-raised-immediately
