### PR TITLE
Added status_update method to Getting Started

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -28,9 +28,10 @@ Hello Tweepy
    for tweet in public_tweets:
        print tweet.text
 
-This example will download your home timeline tweets and print each
-one of their texts to the console. Twitter requires all requests to
-use OAuth for authentication.
+   api.update_status('Hello Twitter!')
+
+This example will download your home timeline tweets, print each
+one of their texts to the console, then post a 'Hello Twitter' status to your timeline. Twitter requires all requests to use OAuth for authentication.
 The :ref:`auth_tutorial` goes into more details about authentication.
 
 API


### PR DESCRIPTION
Just something to make the guide quicker to navigate, I was looking around and couldn't find this in the docs quickly. I think it'd be useful for people to see when they first open up the "Getting Started" page. 
