### PR TITLE
Update streaming.py

### DIFF
--- a/tweepy/streaming.py
+++ b/tweepy/streaming.py
@@ -310,7 +310,9 @@ class Stream(object):
         while self.running and not resp.raw.closed:
             length = 0
             while not resp.raw.closed:
-                line = buf.read_line().strip()
+                line = buf.read_line()
+                if line:
+                    line = line.strip()
                 if not line:
                     self.listener.keep_alive()  # keep-alive new lines are expected
                 elif line.isdigit():


### PR DESCRIPTION
if buf.read_line() returns none, then buf.read_line().strip() obviously fails

this feels like a kludge but it seems to work, and working is better than not working so maybe this is a useful pull request
---

edit: this might be fixed by PR#652 but I'm not sure
