### PR TITLE
[docs] Lists can have 5,000 members

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -645,6 +645,18 @@ List Methods
    :param id: the ID of the user to add as a member
    :rtype: :class:`List` object
 
+.. method:: API.add_list_members(screen_name, user_id, slug, list_id, owner_id, owner_screen_name)
+
+   Add up to 100 members to a list. The authenticated user must own the list to be
+   able to add members to it. Lists are limited to 5,000 members.
+
+   :param screen_name: A comma separated list of screen names, up to 100 are allowed in a single request
+   :param user_id: A comma separated list of user IDs, up to 100 are allowed in a single request
+   :param slug: |slug|
+   :param list_id: The numerical id of the list
+   :param owner_id: The user ID of the user who owns the list being requested by a slug
+   :param owner_screen_name: The screen name of the user who owns the list being requested by a slug
+   :rtype: :class:`List` object
 
 .. method:: API.remove_list_member(slug, id)
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -639,7 +639,7 @@ List Methods
 .. method:: API.add_list_member(slug, id)
 
    Add a member to a list. The authenticated user must own the list to be
-   able to add members to it. Lists are limited to having 500 members.
+   able to add members to it. Lists are limited to 5,000 members.
 
    :param slug: |slug|
    :param id: the ID of the user to add as a member


### PR DESCRIPTION
https://dev.twitter.com/rest/reference/post/lists/members/create

Also documents `add_list_members` to docs, which is there in code.

---

TODO for someone else for the future:
- [ ] check if `add_list_member` needs its documented params updating
- [ ] `remove_list_members` needs documenting
