### PR TITLE
Removing auth.secure = True since it doesnt seem to exist anymore.

### DIFF
--- a/examples/oauth.py
+++ b/examples/oauth.py
@@ -19,7 +19,6 @@ access_token=""
 access_token_secret=""
 
 auth = tweepy.OAuthHandler(consumer_key, consumer_secret)
-auth.secure = True
 auth.set_access_token(access_token, access_token_secret)
 
 api = tweepy.API(auth)


### PR DESCRIPTION
Looks like OAuthHandler class no longer references "secure" anywhere. Just thought i'd clean the example up a bit. 
