### PR TITLE
Fix AttributeError

### DIFF
--- a/tweepy/streaming.py
+++ b/tweepy/streaming.py
@@ -310,11 +310,11 @@ class Stream(object):
         while self.running and not resp.raw.closed:
             length = 0
             while not resp.raw.closed:
-                line = buf.read_line().strip()
+                line = buf.read_line()
                 if not line:
                     self.listener.keep_alive()  # keep-alive new lines are expected
-                elif line.isdigit():
-                    length = int(line)
+                elif line.strip().isdigit():
+                    length = int(line.strip())
                     break
                 else:
                     raise TweepError('Expecting length, unexpected value found')


### PR DESCRIPTION
read_line() can return None. Call strip() after checking for this.

Fix #698