### PR TITLE
Adds `auto_populate_reply_metadata` attribute on status endpoints

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -98,13 +98,14 @@ Status methods
    :rtype: :class:`Status` object
 
 
-.. method:: API.update_status(status, [in_reply_to_status_id], [lat], [long], [source], [place_id])
+.. method:: API.update_status(status, [in_reply_to_status_id], [auto_populate_reply_metadata], [lat], [long], [source], [place_id])
 
    Update the authenticated user's status. Statuses that are duplicates
    or too long will be silently ignored.
 
    :param status: The text of your status update.
    :param in_reply_to_status_id: The ID of an existing status that the update is in reply to.
+   :param auto_populate_reply_metadata: Whether to automatically include the @mentions in the status metadata.
    :param lat: The location's latitude that this tweet refers to.
    :param long: The location's longitude that this tweet refers to.
    :param source: Source of the update. Only supported by Identi.ca. Twitter ignores this parameter.
@@ -112,7 +113,7 @@ Status methods
    :rtype: :class:`Status` object
 
 
-.. method:: API.update_with_media(filename, [status], [in_reply_to_status_id], [lat], [long], [source], [place_id], [file])
+.. method:: API.update_with_media(filename, [status], [in_reply_to_status_id], [auto_populate_reply_metadata], [lat], [long], [source], [place_id], [file])
 
    Update the authenticated user's status. Statuses that are duplicates
    or too long will be silently ignored.
@@ -120,6 +121,7 @@ Status methods
    :param filename: The filename of the image to upload. This will automatically be opened unless `file` is specified
    :param status: The text of your status update.
    :param in_reply_to_status_id: The ID of an existing status that the update is in reply to.
+   :param auto_populate_reply_metadata: Whether to automatically include the @mentions in the status metadata.
    :param lat: The location's latitude that this tweet refers to.
    :param long: The location's longitude that this tweet refers to.
    :param source: Source of the update. Only supported by Identi.ca. Twitter ignores this parameter.

--- a/tweepy/api.py
+++ b/tweepy/api.py
@@ -177,7 +177,7 @@ class API(object):
 
     def update_status(self, *args, **kwargs):
         """ :reference: https://dev.twitter.com/rest/reference/post/statuses/update
-            :allowed_param:'status', 'in_reply_to_status_id', 'in_reply_to_status_id_str', 'lat', 'long', 'source', 'place_id', 'display_coordinates', 'media_ids'
+            :allowed_param:'status', 'in_reply_to_status_id', 'in_reply_to_status_id_str', 'auto_populate_reply_metadata', 'lat', 'long', 'source', 'place_id', 'display_coordinates', 'media_ids'
         """
         post_data = {}
         media_ids = kwargs.pop("media_ids", None)
@@ -189,7 +189,7 @@ class API(object):
             path='/statuses/update.json',
             method='POST',
             payload_type='status',
-            allowed_param=['status', 'in_reply_to_status_id', 'in_reply_to_status_id_str','lat', 'long', 'source', 'place_id', 'display_coordinates'],
+            allowed_param=['status', 'in_reply_to_status_id', 'in_reply_to_status_id_str', 'auto_populate_reply_metadata', 'lat', 'long', 'source', 'place_id', 'display_coordinates'],
             require_auth=True
         )(post_data=post_data, *args, **kwargs)
 
@@ -213,7 +213,7 @@ class API(object):
 
     def update_with_media(self, filename, *args, **kwargs):
         """ :reference: https://dev.twitter.com/rest/reference/post/statuses/update_with_media
-            :allowed_param:'status', 'possibly_sensitive', 'in_reply_to_status_id', 'in_reply_to_status_id_str', 'lat', 'long', 'place_id', 'display_coordinates'
+            :allowed_param:'status', 'possibly_sensitive', 'in_reply_to_status_id', 'in_reply_to_status_id_str', 'auto_populate_reply_metadata', 'lat', 'long', 'place_id', 'display_coordinates'
         """
         f = kwargs.pop('file', None)
         headers, post_data = API._pack_image(filename, 3072, form_field='media[]', f=f)
@@ -225,8 +225,8 @@ class API(object):
             method='POST',
             payload_type='status',
             allowed_param=[
-                'status', 'possibly_sensitive', 'in_reply_to_status_id', 'in_reply_to_status_id_str', 
-                'lat', 'long', 'place_id', 'display_coordinates'
+                'status', 'possibly_sensitive', 'in_reply_to_status_id', 'in_reply_to_status_id_str',
+                'auto_populate_reply_metadata', 'lat', 'long', 'place_id', 'display_coordinates'
             ],
             require_auth=True
         )(*args, **kwargs)


### PR DESCRIPTION
In order to get the benefits from the 140 character changes described in #737 we need to include the `auto_populate_reply_metadata` boolean parameter described in the updated [twitter REST API documentation](https://dev.twitter.com/overview/api/upcoming-changes-to-tweets).

This PR adds this parameter to the two status update endpoints and updates the relevant documentation.
