### PR TITLE
replace raw print() calls with proper logging-based calls

### DIFF
--- a/tweepy/binder.py
+++ b/tweepy/binder.py
@@ -158,7 +158,7 @@ def bind_api(**config):
                                 sleep_time = self._reset_time - int(time.time())
                                 if sleep_time > 0:
                                     if self.wait_on_rate_limit_notify:
-                                        print("Rate limit reached. Sleeping for:", sleep_time)
+                                        log.warning("Rate limit reached. Sleeping for: %d" % sleep_time)
                                     time.sleep(sleep_time + 5)  # sleep for few extra sec
 
                 # if self.wait_on_rate_limit and self._reset_time is not None and \
@@ -166,7 +166,7 @@ def bind_api(**config):
                 #     sleep_time = self._reset_time - int(time.time())
                 #     if sleep_time > 0:
                 #         if self.wait_on_rate_limit_notify:
-                #             print("Rate limit reached. Sleeping for: " + str(sleep_time))
+                #             log.warning("Rate limit reached. Sleeping for: %d" % sleep_time)
                 #         time.sleep(sleep_time + 5)  # sleep for few extra sec
 
                 # Apply authentication

--- a/tweepy/cache.py
+++ b/tweepy/cache.py
@@ -8,6 +8,7 @@ import time
 import datetime
 import threading
 import os
+import logging
 
 try:
     import cPickle as pickle
@@ -27,6 +28,7 @@ except ImportError:
     # TODO: use win32file
     pass
 
+log = logging.getLogger('tweepy.cache')
 
 class Cache(object):
     """Cache interface"""
@@ -157,7 +159,7 @@ class FileCache(Cache):
             self._lock_file = self._lock_file_win32
             self._unlock_file = self._unlock_file_win32
         else:
-            print('Warning! FileCache locking not supported on this system!')
+            log.warning('FileCache locking not supported on this system!')
             self._lock_file = self._lock_file_dummy
             self._unlock_file = self._unlock_file_dummy
 


### PR DESCRIPTION
Hi,
Thanks for a great Twitter library!

I noticed that some running status messages are printed using the basic `print()` function instead of the more suited `logging`-based reporting functions, e.g. `logging.warning()`. This is particularly inconvenient when you implement `stdout` redirection of data from a Twitter-based program, because if you get rate-limited the status message will slip with the stream output you are processing, e.g. JSON Tweets from a `lookup` API call.
I adapted the relevant code to make sure all reporting is done using the `logging` module (that uses `stderr` output as it should) instead of the naive `print()` function.
Hope to see this improvement in upcoming maintenance versions :)

Cheers!
Hugo.
