### PR TITLE
read_line() NoneType bug fix

### DIFF
--- a/tweepy/streaming.py
+++ b/tweepy/streaming.py
@@ -310,7 +310,9 @@ class Stream(object):
         while self.running and not resp.raw.closed:
             length = 0
             while not resp.raw.closed:
-                line = buf.read_line().strip()
+                line = buf.read_line()
+                if isinstance(line, str):
+                    line = line.strip()
                 if not line:
                     self.listener.keep_alive()  # keep-alive new lines are expected
                 elif line.isdigit():


### PR DESCRIPTION
While running a Twitter Stream for a few hours, I eventually receive a bug that claims that buf.read_line() is None, and strip() is not a function of NoneType.  This is my proposed bandaid:

https://github.com/tweepy/tweepy/blob/master/tweepy/streaming.py#L313
