### PR TITLE
Fix fatal errors in streaming

### DIFF
--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -175,6 +175,23 @@ class TweepyStreamReadBufferTests(unittest.TestCase):
         # The mocked function not have been called at all since the stream looks closed
         self.assertEqual(mock_read.call_count, 0)
 
+    @skip
+    def test_read_incomplete_buffer(self):
+        from six.moves import http_client as httplib
+        for length in [1, 2, 5, 10, 20, 50]:
+            with self.assertRaises(httplib.IncompleteRead):
+                msg = "11\n".replace('\n', '')
+                buf = ReadBuffer(six.BytesIO(six.b(msg)), length)
+                buf.read_line()
+            with self.assertRaises(httplib.IncompleteRead):
+                msg = '{id:12345}'
+                buf = ReadBuffer(six.BytesIO(six.b(msg)), length)
+                buf.read_len(len(msg) - 1)
+            with self.assertRaises(httplib.IncompleteRead):
+                msg = '{id:23456, test:"blah"}\n'
+                buf = ReadBuffer(six.BytesIO(six.b(msg)), length)
+                buf.read_len(len(msg) - 2)
+
     def test_read_unicode_tweet(self):
         stream = six.b('11\n{id:12345}\n\n23\n{id:23456, test:"\xe3\x81\x93"}\n\n')
         for length in [1, 2, 5, 10, 20, 50]:


### PR DESCRIPTION
Trying to fix several fatal errors, occurring when the connection breaks while reading. These errors were observed in two locations:
- buf.read_line() or buf.read_len() returns None when the connection is closed before completing the read. later  on, this output (None) was considered as a string and the program crashed as a side-effect (with AttributionError).
- httplib.IncompleteRead was caught in requests, and propagated through buf.read_line() or buf.read_len(). In this case, the retry mechanism didn't catch HTTP errors so it didn't try to reconnect as expected.

These problems were fixed as follows:
- buf.read_line() or buf.read_len() fails with httplib.IncompleteRead when the connection breaks in the middle.
- The retry mechanism treats httplib.HTTPError similarly to timeouts and disconnections errors, following [Twitter's reconnecting advice](https://dev.twitter.com/streaming/overview/connecting).
