### PR TITLE
Update streaming.py to resolve issue #698

### DIFF
--- a/tweepy/streaming.py
+++ b/tweepy/streaming.py
@@ -310,7 +310,11 @@ class Stream(object):
         while self.running and not resp.raw.closed:
             length = 0
             while not resp.raw.closed:
-                line = buf.read_line().strip()
+                line = buf.read_line() #buf.read_line() may return none and hence stirip will give an error
+                try:
+                    line = line.strip()
+                except AttributeError:
+                    pass
                 if not line:
                     self.listener.keep_alive()  # keep-alive new lines are expected
                 elif line.isdigit():

--- a/tweepy/streaming.py
+++ b/tweepy/streaming.py
@@ -314,7 +314,7 @@ class Stream(object):
                 try:
                     line = line.strip()
                 except AttributeError:
-                    pass
+                    continue
                 if not line:
                     self.listener.keep_alive()  # keep-alive new lines are expected
                 elif line.isdigit():


### PR DESCRIPTION
In streaming.py at line# 313:
when buf.read_line() is called, it may return NoneType and when applying strip() it will generate AttribiteError. Hence to fix this placing the line into try-except block.
