### PR TITLE
added and implemented retweet_text() and updated requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ requests>=2.11.1
 requests_oauthlib>=0.7.0
 six>=1.10.0
 PySocks>=1.5.7
+mechanicalsoup>=0.6.0

--- a/tweepy/utils.py
+++ b/tweepy/utils.py
@@ -10,7 +10,7 @@ import six
 from six.moves.urllib.parse import quote
 
 from email.utils import parsedate
-
+import mechanicalsoup
 
 def parse_datetime(string):
     return datetime(*(parsedate(string)[:6]))
@@ -56,3 +56,19 @@ def import_simplejson():
 def list_to_csv(item_list):
     if item_list:
         return ','.join([str(i) for i in item_list])
+
+def retweet_text(link):
+    """
+    preconditions:
+    link is a valid link to a tweet containing retweeted text
+
+    postconditions:
+    returns the retweeted text of the tweet
+    if the preconditions are not met it bad things will happen
+    --maybe it throws an exception
+    """
+    browser = mechanicalsoup.Browser()
+    retweet = browser.get(link)
+    retweet = retweet.soup.findAll('div', class_="QuoteTweet-text")[0]
+    retweet = retweet.text
+    return retweet


### PR DESCRIPTION
see docstring for information about what it does

added mechanicalsoup to requirements.txt because retweet_text uses mechanicalsoup

some context for why I made this:
was working on a twitter bot at a hackathon and we wanted to get retweet text of a retweet, the api at that point had the capability to get the url of the retweet but we wanted to get the text of the original tweet that was being retweeted.