### PR TITLE
Use built in json library

### DIFF
--- a/tweepy/parsers.py
+++ b/tweepy/parsers.py
@@ -4,8 +4,8 @@
 
 from __future__ import print_function
 
+import json as json_lib
 from tweepy.models import ModelFactory
-from tweepy.utils import import_simplejson
 from tweepy.error import TweepError
 
 
@@ -44,12 +44,9 @@ class JSONParser(Parser):
 
     payload_format = 'json'
 
-    def __init__(self):
-        self.json_lib = import_simplejson()
-
     def parse(self, method, payload):
         try:
-            json = self.json_lib.loads(payload)
+            json = json_lib.loads(payload)
         except Exception as e:
             raise TweepError('Failed to parse JSON payload: %s' % e)
 
@@ -63,7 +60,7 @@ class JSONParser(Parser):
             return json
 
     def parse_error(self, payload):
-        error_object = self.json_lib.loads(payload)
+        error_object = json_lib.loads(payload)
 
         if 'error' in error_object:
             reason = error_object['error']

--- a/tweepy/streaming.py
+++ b/tweepy/streaming.py
@@ -10,6 +10,7 @@ import logging
 import re
 import requests
 import sys
+import json
 from requests.exceptions import Timeout
 from threading import Thread
 from time import sleep
@@ -21,9 +22,6 @@ import ssl
 from tweepy.models import Status
 from tweepy.api import API
 from tweepy.error import TweepError
-
-from tweepy.utils import import_simplejson
-json = import_simplejson()
 
 STREAM_VERSION = '1.1'
 

--- a/tweepy/utils.py
+++ b/tweepy/utils.py
@@ -17,12 +17,10 @@ def parse_datetime(string):
 
 
 def parse_html_value(html):
-
     return html[html.find('>')+1:html.rfind('<')]
 
 
 def parse_a_href(atag):
-
     start = atag.find('"') + 1
     end = atag.find('"', start)
     return atag[start:end]
@@ -35,22 +33,6 @@ def convert_to_utf8_str(arg):
     elif not isinstance(arg, bytes):
         arg = six.text_type(arg).encode('utf-8')
     return arg
-
-
-def import_simplejson():
-    try:
-        import simplejson as json
-    except ImportError:
-        try:
-            import json  # Python 2.6+
-        except ImportError:
-            try:
-                # Google App Engine
-                from django.utils import simplejson as json
-            except ImportError:
-                raise ImportError("Can't load a json library")
-
-    return json
 
 
 def list_to_csv(item_list):


### PR DESCRIPTION
Python has had a built-in json library since version 2.6, released in 2008. Tweepy's tests no longer include Python 2.5, so they're no reason to use simplejson.

This also removes a complicated import path that made every instance of Tweepy attempt to import a module that's not in requirements.

This commit also removes the json library as an attribute of the `Parser` object. Don't know what it was doing there, besides being unpythonic.