### PR TITLE
`streamListener.filter(follow=)` expects `[str]`

### DIFF
--- a/docs/streaming_how_to.rst
+++ b/docs/streaming_how_to.rst
@@ -83,7 +83,7 @@ the word *python*. The **track** parameter is an array of search terms to stream
 
 This example shows how to use **filter** to stream tweets by a specific user. The **follow** parameter is an array of IDs. ::
 
-  myStream.filter(follow=[2211149702])
+  myStream.filter(follow=["2211149702"])
 
 An easy way to find a single ID is to use one of the many conversion websites: search for 'what is my twitter ID'.
 


### PR DESCRIPTION
Example shows the list of parameters as `int`s; they should be `str`s.