### PR TITLE
Prevent .strip() from being called on None

### DIFF
--- a/tweepy/streaming.py
+++ b/tweepy/streaming.py
@@ -313,10 +313,10 @@ class Stream(object):
         while self.running and not resp.raw.closed:
             length = 0
             while not resp.raw.closed:
-                line = buf.read_line().strip()
+                line = buf.read_line()
                 if not line:
                     self.listener.keep_alive()  # keep-alive new lines are expected
-                elif line.isdigit():
+                elif line.strip().isdigit():
                     length = int(line)
                     break
                 else:


### PR DESCRIPTION
Tweepy streaming has crashed a few times when buf.read_line() returns None and .strip() is subsequently called on it. This change moves the .strip() call to after the return value of read_line() is confirmed to exist.