### PR TITLE
Update streaming.py type check

### DIFF
--- a/tweepy/streaming.py
+++ b/tweepy/streaming.py
@@ -314,7 +314,9 @@ class Stream(object):
             length = 0
             while not resp.raw.closed:
                 line = buf.read_line()
-                if not line:
+                if line is None:
+                    self.listener.keep_alive()  # Not sure, but this might also be a keep-alive
+                elif not line.strip():
                     self.listener.keep_alive()  # keep-alive new lines are expected
                 elif line.strip().isdigit():
                     length = int(line)


### PR DESCRIPTION
Pull request #870 fixed the NoneType errors by moving the strip command, but broke the keep-alive mechanism that was expecting an empty string after the keep-alive command was stripped.

This should fix the keep-alive and also check for None, although it's not clear to me what should happen if NoneType is received here.