### PR TITLE
Handles blank keep-alive new lines

### DIFF
--- a/tweepy/streaming.py
+++ b/tweepy/streaming.py
@@ -313,7 +313,7 @@ class Stream(object):
         while self.running and not resp.raw.closed:
             length = 0
             while not resp.raw.closed:
-                line = buf.read_line()
+                line = buf.read_line().strip()
                 if not line:
                     self.listener.keep_alive()  # keep-alive new lines are expected
                 elif line.strip().isdigit():


### PR DESCRIPTION
Added .strip() to read_line() to handle keep-alive new lines. This is in line with the pip release of Tweepy here: https://pypi.python.org/pypi/tweepy/3.5.0