### PR TITLE
Update api.rst to show error message

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -803,7 +803,7 @@ example, ``tweepy.error.TweepError`` is available as ``tweepy.TweepError``.
    When a ``TweepError`` is raised due to an error Twitter responded with,
    the error code (`as described in the API documentation
    <https://dev.twitter.com/overview/api/response-codes>`_) can be accessed
-   at ``TweepError.message[0]['code']``. Note, however, that ``TweepError``\ s
+   at ``TweepError.response.text``. Note, however, that ``TweepError``\ s
    also may be raised with other things as message (for example plain
    error reason strings).
 


### PR DESCRIPTION
Old documentation incorrectly shows TweepError.message instead of TweepError.response. Fixes issue #774 