### PR TITLE
#1029 - migrate requirements to setup.py, reference in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-requests>=2.11.1
-requests_oauthlib>=0.7.0
-six>=1.10.0
-PySocks>=1.5.7
+--index-url https://pypi.python.org/simple/
+
+-e .

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@
 #from distutils.core import setup
 import re, uuid
 from setuptools import setup, find_packages
-from pip.req import parse_requirements
 
 VERSIONFILE = "tweepy/__init__.py"
 ver_file = open(VERSIONFILE, "rt").read()
@@ -14,9 +13,6 @@ if mo:
 else:
     raise RuntimeError("Unable to find version string in %s." % (VERSIONFILE,))
 
-install_reqs = parse_requirements('requirements.txt', session=uuid.uuid1())
-reqs = [str(req.req) for req in install_reqs]
-
 setup(name="tweepy",
       version=version,
       description="Twitter library for python",
@@ -25,7 +21,12 @@ setup(name="tweepy",
       author_email="tweepy@googlegroups.com",
       url="http://github.com/tweepy/tweepy",
       packages=find_packages(exclude=['tests']),
-      install_requires=reqs,
+      install_requires=[
+          "requests>=2.11.1",
+          "requests_oauthlib>=0.7.0",
+          "six>=1.10.0",
+          "PySocks>=1.5.7",
+      ],
       keywords="twitter library",
       classifiers=[
           'Development Status :: 4 - Beta',


### PR DESCRIPTION
`parse_requirements` is no longer available from `pip`. Followed guidance from https://caremad.io/posts/2013/07/setup-vs-requirement/ to work around this / fix the design bug in putting dependencies in `requirements.txt` instead of `setup.py`