### PR TITLE
updated cursor_tutorial with extended_tweet instructions

### DIFF
--- a/docs/cursor_tutorial.rst
+++ b/docs/cursor_tutorial.rst
@@ -87,7 +87,23 @@ What if you only want n items or pages returned? You pass into the items() or pa
    # Only iterate through the first 200 statuses
    for status in tweepy.Cursor(api.user_timeline).items(200):
        process_status(status)
-   
+
    # Only iterate through the first 3 pages
    for page in tweepy.Cursor(api.user_timeline).pages(3):
        process_page(page)
+
+
+Include Tweets > 140 Characters
+-------------------------------
+
+Since twitter increased the maximum characters allowed in a tweet from 140 to 280, you may notice that tweets greater than 140 characters are truncated with a ...
+If you want your results to include the full text of the long tweets make these simple changes:
+- add the argument tweet_mode='extended' to your Cursor object call
+- change your usages of .text to .full_text
+
+.. code-block :: python
+
+# example code
+tweets = tweepy.Cursor(api.search, tweet_mode='extended')
+for tweet in tweets:
+    content = tweet.full_text


### PR DESCRIPTION
Tweepy, thank you for your work.

I ran into a tweet-truncation hurdle while collecting tweets for a Hungarian language corpus.
tweets greater than 140 characters are truncated back down to 140 characters in the default use case.

This will be a very common problem for computational linguists, and is very easy to overlook until it is too late (ie your corpus is being used for sentiment analysis or some sort of processing down the line).

I could not find proper documentation on how to fix the issue, so I thought I would propose an update to the docs. Hopefully it saves some students some stress and some linguists some lost time.

Thank you again for your work,
Tim