### PR TITLE
Update count parameter for search_users and list_timeline

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -209,7 +209,7 @@ User methods
    :param cursor: |cursor|
    :rtype: list of :class:`User` objects
 
-.. method:: API.search_users(q, [per_page], [page])
+.. method:: API.search_users(q, [count], [page])
 
    Run a search for users similar to Find People button on Twitter.com;
    the same results returned by people search on Twitter.com will be
@@ -218,7 +218,7 @@ User methods
    this API.
 
    :param q: The query to run against people search.
-   :param per_page: Specifies the number of statuses to retrieve. May not be greater than 20.
+   :param count: Specifies the number of statuses to retrieve. May not be greater than 20.
    :param page: |page|
    :rtype: list of :class:`User` objects
 
@@ -613,7 +613,7 @@ List Methods
    :rtype: list of :class:`List` objects
 
 
-.. method:: API.list_timeline(owner, slug, [since_id], [max_id], [per_page], [page])
+.. method:: API.list_timeline(owner, slug, [since_id], [max_id], [count], [page])
 
    Show tweet timeline for members of the specified list.
 
@@ -621,7 +621,7 @@ List Methods
    :param slug: |slug|
    :param since_id: |since_id|
    :param max_id: |max_id|
-   :param per_page: Number of results per a page
+   :param count: Number of results per a page
    :param page: |page|
    :rtype: list of :class:`Status` objects
 


### PR DESCRIPTION
Twitter's API no longer supports "per_page" as a parameter for search_users and list_timeline. Instead, "count" must be used. This is reflected in the most recent Twitter API Documentation. I validated that the "count" parameter works for both search_users and list_timeline using Tweepy 3.6.