### PR TITLE
Wrap APIMethod.execute in try/finally to ensure that the session is closed even on error.

### DIFF
--- a/tweepy/binder.py
+++ b/tweepy/binder.py
@@ -124,7 +124,7 @@ def bind_api(**config):
 
                 self.path = self.path.replace(variable, value)
 
-        def execute(self):
+        def _execute(self):
             self.api.cached_result = False
 
             # Build the request URL
@@ -241,6 +241,12 @@ def bind_api(**config):
                 self.api.cache.store('%s?%s' % (url, urlencode(self.session.params)), result)
 
             return result
+
+        def execute(self):
+            try:
+                return self._execute()
+            finally:
+                self.session.close()
 
     def _call(*args, **kwargs):
         method = APIMethod(args, kwargs)


### PR DESCRIPTION
This fixes https://github.com/tweepy/tweepy/issues/810.