### PR TITLE
Giving options for the `__repr__` of  `Model` class

### DIFF
--- a/tweepy/models.py
+++ b/tweepy/models.py
@@ -38,6 +38,7 @@ class Model(object):
 
     def __init__(self, api=None):
         self._api = api
+        self.object_repr = False
 
     def __getstate__(self):
         # pickle
@@ -66,8 +67,11 @@ class Model(object):
         return results
 
     def __repr__(self):
-        state = ['%s=%s' % (k, repr(v)) for (k, v) in vars(self).items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(state))
+        if not self.object_repr:
+            state = ['%s=%s' % (k, repr(v)) for (k, v) in vars(self).items()]
+            return '%s(%s)' % (self.__class__.__name__, ', '.join(state))
+        else:
+            return object.__repr__(self)
 
 
 class Status(Model):

--- a/tweepy/models.py
+++ b/tweepy/models.py
@@ -33,7 +33,7 @@ class ResultSet(list):
     def ids(self):
         return [item.id for item in self if hasattr(item, 'id')]
 
-
+    
 class Model(object):
 
     def __init__(self, api=None):
@@ -131,6 +131,7 @@ class Status(Model):
         return not result
 
     def __repr__(self):
+        
         try:
             text = self.text
         except:
@@ -139,10 +140,7 @@ class Status(Model):
         string = '[id {}]'.format(self.id) + ' @' + self.author.screen_name + ' : ' + text
 
         return string
-
-    def exp(self):
-        print(self.__class__.__name__)
-
+    
     
 class User(Model):
 

--- a/tweepy/models.py
+++ b/tweepy/models.py
@@ -130,7 +130,20 @@ class Status(Model):
 
         return not result
 
+    def __repr__(self):
+        try:
+            text = self.text
+        except:
+            text = self.full_text
+            
+        string = '[id {}]'.format(self.id) + ' @' + self.author.screen_name + ' : ' + text
 
+        return string
+
+    def exp(self):
+        print(self.__class__.__name__)
+
+    
 class User(Model):
 
     @classmethod


### PR DESCRIPTION
For convenience in viewing the object representation.

Example : let `x` be a `tweepy.models.Status` object
```
>>> x.object_repr
False
>>> x
Status(in_reply_to_status_id_str=None, in_reply_to_user_id=None, place=None, 
....
....
*******quite lengthy*******
....
....
 'lang': 'en'})
```
If you want the short version, we can set the `object_repr=True`.

```
x.object_repr=True
>>> x
<tweepy.models.Status object at 0xb17562ac>
```

This will apply for all subclasses of `Model`.

Regards.