### PR TITLE
Add a support of the 'perform_block' param for api.report_spam() method

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -489,7 +489,7 @@ Block Methods
 Spam Reporting Methods
 ----------------------
 
-.. method:: API.report_spam([id/user_id/screen_name])
+.. method:: API.report_spam([id/user_id/screen_name/perform_block])
 
    The user specified in the id is blocked by the authenticated user and
    reported as a spammer.
@@ -497,6 +497,7 @@ Spam Reporting Methods
    :param id: |uid|
    :param screen_name: |screen_name|
    :param user_id: |user_id|
+   :param perform_block: A boolean indicating if the reported account should be blocked. Defaults to True.
    :rtype: :class:`User` object
 
 

--- a/tweepy/api.py
+++ b/tweepy/api.py
@@ -868,14 +868,14 @@ class API(object):
     @property
     def report_spam(self):
         """ :reference: https://dev.twitter.com/rest/reference/post/users/report_spam
-            :allowed_param:'user_id', 'screen_name'
+            :allowed_param:'user_id', 'screen_name', 'perform_block'
         """
         return bind_api(
             api=self,
             path='/users/report_spam.json',
             method='POST',
             payload_type='user',
-            allowed_param=['user_id', 'screen_name'],
+            allowed_param=['user_id', 'screen_name', 'perform_block'],
             require_auth=True
         )
 


### PR DESCRIPTION
Now tweepy's `api.report_spam()` method only accept `user_id` and `screen_name` params. So when we report spam for an account, the account always be blocked. This PR supports the `perform_block` param and enable to report spam without blocking the target account (by setting it to `False`).

See also: [POST users/report_spam — Twitter Developers](https://developer.twitter.com/en/docs/accounts-and-users/mute-block-report-users/api-reference/post-users-report_spam)