### PR TITLE
Allow to close stream on keep-alive messages (Fixes #897 #773)

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -35,3 +35,4 @@ Kohei YOSHIDA
 Mark Smith (@judy2k)
 Steven Skoczen (@skoczen)
 Samuel (@obskyr)
+Luc Besuchet (@lbesuchet)


### PR DESCRIPTION
This fix allows to disconnect the stream at the next keep-alive message received.
This is possible by either calling disconnect() or having keep_alive() returning False.