### PR TITLE
Twitter get DM fixed

### DIFF
--- a/tweepy/api.py
+++ b/tweepy/api.py
@@ -414,7 +414,7 @@ class API(object):
             api=self,
             path='/direct_messages/events/list.json',
             payload_type='direct_message', payload_list=True,
-            allowed_param=['since_id', 'cursor', 'count', 'full_text'],
+            allowed_param=['cursor', 'count'],
             require_auth=True
         )
 

--- a/tweepy/api.py
+++ b/tweepy/api.py
@@ -414,7 +414,7 @@ class API(object):
             api=self,
             path='/direct_messages/events/list.json',
             payload_type='direct_message', payload_list=True,
-            allowed_param=['since_id', 'max_id', 'count', 'full_text'],
+            allowed_param=['since_id', 'cursor', 'count', 'full_text'],
             require_auth=True
         )
 

--- a/tweepy/api.py
+++ b/tweepy/api.py
@@ -449,12 +449,15 @@ class API(object):
         """ :reference: https://dev.twitter.com/rest/reference/post/direct_messages/new
             :allowed_param:'user', 'screen_name', 'user_id', 'text'
         """
+
+        # todo: handle request and response return type
+
         return bind_api(
             api=self,
-            path='/direct_messages/new.json',
+            path='/direct_messages/events/new.json',
             method='POST',
             payload_type='direct_message',
-            allowed_param=['user', 'screen_name', 'user_id', 'text'],
+            allowed_param=['type', 'message_data', 'recipient_id'],
             require_auth=True
         )
 

--- a/tweepy/api.py
+++ b/tweepy/api.py
@@ -190,7 +190,7 @@ class API(object):
             path='/statuses/update.json',
             method='POST',
             payload_type='status',
-            allowed_param=['status', 'in_reply_to_status_id', 'in_reply_to_status_id_str', 'auto_populate_reply_metadata', 'lat', 'long', 'source', 'place_id', 'display_coordinates'],
+            allowed_param=['status', 'in_reply_to_status_id', 'in_reply_to_status_id_str', 'auto_populate_reply_metadata', 'exclude_reply_user_ids', 'lat', 'long', 'source', 'place_id', 'display_coordinates'],
             require_auth=True
         )(post_data=post_data, *args, **kwargs)
 

--- a/tweepy/api.py
+++ b/tweepy/api.py
@@ -412,7 +412,7 @@ class API(object):
         """
         return bind_api(
             api=self,
-            path='/direct_messages.json',
+            path='/direct_messages/events/list.json',
             payload_type='direct_message', payload_list=True,
             allowed_param=['since_id', 'max_id', 'count', 'full_text'],
             require_auth=True

--- a/tweepy/binder.py
+++ b/tweepy/binder.py
@@ -182,12 +182,41 @@ def bind_api(**config):
 
                 # Execute request
                 try:
-                    resp = self.session.request(self.method,
-                                                full_url,
-                                                data=self.post_data,
-                                                timeout=self.api.timeout,
-                                                auth=auth,
-                                                proxies=self.api.proxy)
+                    try:
+                        if "type" in self.session.params and self.session.params["type"] == "message_create":
+                            data = {
+                                        "event": {
+                                            "type": self.session.params["type"],
+                                            "message_create": {
+                                                "target": {
+                                                    "recipient_id": self.session.params["recipient_id"]
+                                                },
+                                                "message_data": {
+                                                    "text": self.session.params["text"]
+                                                }
+                                            }
+                                        }
+                                    }
+                            resp = self.session.request(self.method,
+                                                        full_url,
+                                                        json=data,
+                                                        timeout=self.api.timeout,
+                                                        auth=auth,
+                                                        proxies=self.api.proxy)
+                        else:
+                            resp = self.session.request(self.method,
+                                                        full_url,
+                                                        data=self.post_data,
+                                                        timeout=self.api.timeout,
+                                                        auth=auth,
+                                                        proxies=self.api.proxy)
+                    except Exception:
+                        resp = self.session.request(self.method,
+                                                    full_url,
+                                                    data=self.post_data,
+                                                    timeout=self.api.timeout,
+                                                    auth=auth,
+                                                    proxies=self.api.proxy)
                 except Exception as e:
                     six.reraise(TweepError, TweepError('Failed to send request: %s' % e), sys.exc_info()[2])
 

--- a/tweepy/models.py
+++ b/tweepy/models.py
@@ -5,7 +5,7 @@
 from __future__ import absolute_import, print_function
 
 from tweepy.utils import parse_datetime, parse_html_value, parse_a_href
-
+import json as pyjson
 
 class ResultSet(list):
     """A list like object that holds results from a Twitter API query."""
@@ -207,7 +207,7 @@ class DirectMessage(Model):
     @classmethod
     def parse(cls, api, json):
         dm = cls(api)
-        for k, v in json.items():
+        for k, v in pyjson.loads(dm._api.last_response.text).items():
             if k == 'sender' or k == 'recipient':
                 setattr(dm, k, User.parse(api, v))
             elif k == 'created_at':


### PR DESCRIPTION
Twitter get dm functionality is fixed accordingly new API.

Possible usage is:

```
next_cursor = None
while next_cursor is not None:
	if next_cursor is not None:
	    direct_messages = connection.direct_messages(cursor=next_cursor, count=50)
	else:
	    direct_messages = connection.direct_messages(count=50)
	try:
	    next_cursor = direct_messages[0].next_cursor
	except Exception:
	    next_cursor = None

	# Do your stuff
```