### PR TITLE
Allow optionally setting daemon flag on async threads.

### DIFF
--- a/tweepy/streaming.py
+++ b/tweepy/streaming.py
@@ -364,6 +364,7 @@ class Stream(object):
         self.running = True
         if is_async:
             self._thread = Thread(target=self._run)
+            self._thread.daemon = True
             self._thread.start()
         else:
             self._run()

--- a/tweepy/streaming.py
+++ b/tweepy/streaming.py
@@ -195,6 +195,7 @@ class Stream(object):
         self.auth = auth
         self.listener = listener
         self.running = False
+        self.daemon = options.get("daemon", False)
         self.timeout = options.get("timeout", 300.0)
         self.retry_count = options.get("retry_count")
         # values according to
@@ -364,7 +365,7 @@ class Stream(object):
         self.running = True
         if is_async:
             self._thread = Thread(target=self._run)
-            self._thread.daemon = True
+            self._thread.daemon = self.daemon
             self._thread.start()
         else:
             self._run()


### PR DESCRIPTION
Would you be open to a PR which sets the daemon flag on async threads?

https://docs.python.org/3/library/threading.html#threading.Thread.daemon

This will allow python scripts to exit cleanly when all non-daemon threads are stopped. The current behavior is that the streaming thread stays up and prevents the script from exiting.

[EDIT]
Changed PR to optionally allow setting daemon flag, but maintain the default behavior of setting it to false. 
