### PR TITLE
Travis CI: Add Python 3.7 to the testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: false
-
 language: python
 cache: pip
 
@@ -8,6 +6,12 @@ python:
 - '3.4'
 - '3.5'
 - '3.6'
+
+matrix:
+  fast_finish: true
+  include:
+    - python: '3.7'
+      dist: xenial  # required for Python >= 3.7 (travis-ci/travis-ci#9069)
 
 env:
   global:
@@ -58,6 +62,3 @@ deploy:
   on:
     repo: tweepy/tweepy
     tags: true
-
-matrix:
-  fast_finish: true


### PR DESCRIPTION
Also: [Travis are now recommending removing the __sudo__ tag](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration)