### PR TITLE
Correction on is_async argument of filter function

### DIFF
--- a/docs/streaming_how_to.rst
+++ b/docs/streaming_how_to.rst
@@ -96,7 +96,7 @@ Streams do not terminate unless the connection is closed, blocking the thread.
 Tweepy offers a convenient **async** parameter on **filter** so the stream will run on a new
 thread. For example ::
 
-  myStream.filter(track=['python'], async=True)
+  myStream.filter(track=['python'], is_async=True)
 
 Handling Errors
 ---------------


### PR DESCRIPTION
The documentation shows how to use filter's is_async argument, but it calls as async and not as is_async. Just a minor issue.