### PR TITLE
Fix request_token not defined when not calling get_authorization_url

### DIFF
--- a/tweepy/auth.py
+++ b/tweepy/auth.py
@@ -44,6 +44,7 @@ class OAuthHandler(AuthHandler):
         self.access_token_secret = None
         self.callback = callback
         self.username = None
+        self.request_token = {}
         self.oauth = OAuth1Session(consumer_key,
                                    client_secret=consumer_secret,
                                    callback_uri=self.callback)


### PR DESCRIPTION
When you're doing auth dance, you use `.get_authorization_url()` for redirecting the user. 

But when you already have the token and verifier and just want to exchange for an access_token, you get an error because `OAuthHandler object has no attribute 'request_token'`. So, I just declared the `request_token` attr on the init.