### PR TITLE
Fixed syntax error in cursor tutorial documentation

### DIFF
--- a/docs/cursor_tutorial.rst
+++ b/docs/cursor_tutorial.rst
@@ -103,7 +103,7 @@ If you want your results to include the full text of the long tweets make these 
 
 .. code-block :: python
 
-# example code
-tweets = tweepy.Cursor(api.search, tweet_mode='extended')
-for tweet in tweets:
-    content = tweet.full_text
+   # example code
+   tweets = tweepy.Cursor(api.search, tweet_mode='extended')
+   for tweet in tweets:
+      content = tweet.full_text


### PR DESCRIPTION
The example code for the last block in the cursor tutorial was not indented correctly, and as a result not displaying correctly on the documentation page.  Fixed the indention.