### PR TITLE
docs/api.rst: update_status now reflects the code

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -107,18 +107,21 @@ Status methods
    :rtype: :class:`Status` object
 
 
-.. method:: API.update_status(status, [in_reply_to_status_id], [auto_populate_reply_metadata], [lat], [long], [source], [place_id])
+.. method:: API.update_status(status, [in_reply_to_status_id], [in_reply_to_status_id_str], [auto_populate_reply_metadata], [lat], [long], [source], [place_id], [display_coordinates], [media_ids])
 
    Update the authenticated user's status. Statuses that are duplicates
    or too long will be silently ignored.
 
    :param status: The text of your status update.
    :param in_reply_to_status_id: The ID of an existing status that the update is in reply to.
+   :param in_reply_to_status_id_str: The ID of an existing status that the update is in reply to (as string).
    :param auto_populate_reply_metadata: Whether to automatically include the @mentions in the status metadata.
    :param lat: The location's latitude that this tweet refers to.
    :param long: The location's longitude that this tweet refers to.
    :param source: Source of the update. Only supported by Identi.ca. Twitter ignores this parameter.
    :param place_id: Twitter ID of location which is listed in the Tweet if geolocation is enabled for the user.
+   :param display_coordinates: Whether or not to put a pin on the exact coordinates a Tweet has been sent from.
+   :param media_ids: A comma-delimited list of media_ids to associate with the Tweet.
    :rtype: :class:`Status` object
 
 


### PR DESCRIPTION
The title says it all. docs/api.rst failed to document a couple of parameters the code for update_status() appears to support (and has supported for quite some time).