### PR TITLE
Add cursor param to blocks_ids and mutes_ids

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -477,11 +477,12 @@ Block Methods
    :rtype: list of :class:`User` objects
 
 
-.. method:: API.blocks_ids()
+.. method:: API.blocks_ids([cursor])
 
    Returns an array of numeric user ids the authenticating user is
    blocking.
 
+   :param cursor: |cursor|
    :rtype: list of Integers
 
 
@@ -508,10 +509,11 @@ Mute Methods
    :rtype: :class:`User` object
 
 
-.. method:: API.mutes_ids()
+.. method:: API.mutes_ids([cursor])
 
    Returns an array of numeric user ids the authenticating user has muted.
 
+   :param cursor: |cursor|
    :rtype: list of Integers
 
 

--- a/tweepy/api.py
+++ b/tweepy/api.py
@@ -789,11 +789,14 @@ class API(object):
 
     @property
     def mutes_ids(self):
-        """ :reference: https://developer.twitter.com/en/docs/accounts-and-users/mute-block-report-users/api-reference/get-mutes-users-ids """
+        """ :reference: https://developer.twitter.com/en/docs/accounts-and-users/mute-block-report-users/api-reference/get-mutes-users-ids
+            :allowed_param:'cursor'
+        """
         return bind_api(
             api=self,
             path='/mutes/users/ids.json',
             payload_type='json',
+            allowed_param=['cursor'],
             require_auth=True
         )
 
@@ -840,11 +843,14 @@ class API(object):
 
     @property
     def blocks_ids(self):
-        """ :reference: https://developer.twitter.com/en/docs/accounts-and-users/mute-block-report-users/api-reference/get-blocks-ids """
+        """ :reference: https://developer.twitter.com/en/docs/accounts-and-users/mute-block-report-users/api-reference/get-blocks-ids
+            :allowed_param:'cursor'
+        """
         return bind_api(
             api=self,
             path='/blocks/ids.json',
             payload_type='json',
+            allowed_param=['cursor'],
             require_auth=True
         )
 


### PR DESCRIPTION
Twitter has added cursor support to both [mutes_ids](https://developer.twitter.com/en/docs/accounts-and-users/mute-block-report-users/api-reference/get-mutes-users-ids#parameters) and [blocks_ids](https://developer.twitter.com/en/docs/accounts-and-users/mute-block-report-users/api-reference/get-blocks-ids#parameters).  