### PR TITLE
Fix help() calls on the instantiated API, by remove confusing propert…

### DIFF
--- a/tweepy/api.py
+++ b/tweepy/api.py
@@ -78,8 +78,7 @@ class API(object):
                 )
             )
 
-    @property
-    def home_timeline(self):
+    def home_timeline(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/tweets/timelines/api-reference/get-statuses-home_timeline
             :allowed_param:'since_id', 'max_id', 'count'
         """
@@ -89,15 +88,15 @@ class API(object):
             payload_type='status', payload_list=True,
             allowed_param=['since_id', 'max_id', 'count'],
             require_auth=True
-        )
+        )(*args, **kwargs)
+    home_timeline.pagination_mode = 'id'
 
     def statuses_lookup(self, id_, include_entities=None,
                         trim_user=None, map_=None, tweet_mode=None):
         return self._statuses_lookup(list_to_csv(id_), include_entities,
                                      trim_user, map_, tweet_mode)
 
-    @property
-    def _statuses_lookup(self):
+    def _statuses_lookup(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/tweets/post-and-engage/api-reference/get-statuses-lookup
             :allowed_param:'id', 'include_entities', 'trim_user', 'map', 'tweet_mode'
         """
@@ -107,10 +106,9 @@ class API(object):
             payload_type='status', payload_list=True,
             allowed_param=['id', 'include_entities', 'trim_user', 'map', 'tweet_mode'],
             require_auth=True
-        )
+        )(*args, **kwargs)
 
-    @property
-    def user_timeline(self):
+    def user_timeline(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/tweets/timelines/api-reference/get-statuses-user_timeline
             :allowed_param:'id', 'user_id', 'screen_name', 'since_id', 'max_id', 'count', 'include_rts', 'trim_user', 'exclude_replies'
         """
@@ -121,10 +119,10 @@ class API(object):
             allowed_param=['id', 'user_id', 'screen_name', 'since_id',
                            'max_id', 'count', 'include_rts', 'trim_user',
                            'exclude_replies']
-        )
+        )(*args, **kwargs)
+    user_timeline.pagination_mode = 'id'
 
-    @property
-    def mentions_timeline(self):
+    def mentions_timeline(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/tweets/timelines/api-reference/get-statuses-mentions_timeline
             :allowed_param:'since_id', 'max_id', 'count'
         """
@@ -134,10 +132,10 @@ class API(object):
             payload_type='status', payload_list=True,
             allowed_param=['since_id', 'max_id', 'count'],
             require_auth=True
-        )
+        )(*args, **kwargs)
+    mentions_timeline.pagination_mode = 'id'
 
-    @property
-    def related_results(self):
+    def related_results(self, *args, **kwargs):
         """ :reference: https://dev.twitter.com/docs/api/1.1/get/related_results/show/%3id.format
             :allowed_param:'id'
         """
@@ -147,10 +145,9 @@ class API(object):
             payload_type='relation', payload_list=True,
             allowed_param=['id'],
             require_auth=False
-        )
+        )(*args, **kwargs)
 
-    @property
-    def retweets_of_me(self):
+    def retweets_of_me(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/tweets/post-and-engage/api-reference/get-statuses-retweets_of_me
             :allowed_param:'since_id', 'max_id', 'count'
         """
@@ -160,10 +157,10 @@ class API(object):
             payload_type='status', payload_list=True,
             allowed_param=['since_id', 'max_id', 'count'],
             require_auth=True
-        )
+        )(*args, **kwargs)
+    retweets_of_me.pagination_mode = 'id'
 
-    @property
-    def get_status(self):
+    def get_status(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/tweets/post-and-engage/api-reference/get-statuses-show-id
             :allowed_param:'id'
         """
@@ -172,7 +169,7 @@ class API(object):
             path='/statuses/show.json',
             payload_type='status',
             allowed_param=['id']
-        )
+        )(*args, **kwargs)
 
     def update_status(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/tweets/post-and-engage/api-reference/post-statuses-update
@@ -230,8 +227,7 @@ class API(object):
             require_auth=True
         )(*args, **kwargs)
 
-    @property
-    def destroy_status(self):
+    def destroy_status(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/tweets/post-and-engage/api-reference/post-statuses-destroy-id
             :allowed_param:'id'
         """
@@ -242,10 +238,9 @@ class API(object):
             payload_type='status',
             allowed_param=['id'],
             require_auth=True
-        )
+        )(*args, **kwargs)
 
-    @property
-    def retweet(self):
+    def retweet(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/tweets/post-and-engage/api-reference/post-statuses-retweet-id
             :allowed_param:'id'
         """
@@ -256,10 +251,9 @@ class API(object):
             payload_type='status',
             allowed_param=['id'],
             require_auth=True
-        )
+        )(*args, **kwargs)
 
-    @property
-    def unretweet(self):
+    def unretweet(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/tweets/post-and-engage/api-reference/post-statuses-unretweet-id
             :allowed_param:'id'
         """
@@ -270,10 +264,9 @@ class API(object):
             payload_type='status',
             allowed_param=['id'],
             require_auth=True
-        )
+        )(*args, **kwargs)
 
-    @property
-    def retweets(self):
+    def retweets(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/tweets/post-and-engage/api-reference/get-statuses-retweets-id
             :allowed_param:'id', 'count'
         """
@@ -283,10 +276,9 @@ class API(object):
             payload_type='status', payload_list=True,
             allowed_param=['id', 'count'],
             require_auth=True
-        )
+        )(*args, **kwargs)
 
-    @property
-    def retweeters(self):
+    def retweeters(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/tweets/post-and-engage/api-reference/get-statuses-retweeters-ids
             :allowed_param:'id', 'cursor', 'stringify_ids
         """
@@ -295,10 +287,10 @@ class API(object):
             path='/statuses/retweeters/ids.json',
             payload_type='ids',
             allowed_param=['id', 'cursor', 'stringify_ids']
-        )
+        )(*args, **kwargs)
+    retweeters.pagination_mode = 'cursor'
 
-    @property
-    def get_user(self):
+    def get_user(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-users-show
             :allowed_param:'id', 'user_id', 'screen_name'
         """
@@ -307,10 +299,9 @@ class API(object):
             path='/users/show.json',
             payload_type='user',
             allowed_param=['id', 'user_id', 'screen_name']
-        )
+        )(*args, **kwargs)
 
-    @property
-    def get_oembed(self):
+    def get_oembed(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/tweets/post-and-engage/api-reference/get-statuses-oembed
             :allowed_param:'id', 'url', 'maxwidth', 'hide_media', 'omit_script', 'align', 'related', 'lang'
         """
@@ -319,10 +310,13 @@ class API(object):
             path='/statuses/oembed.json',
             payload_type='json',
             allowed_param=['id', 'url', 'maxwidth', 'hide_media', 'omit_script', 'align', 'related', 'lang']
-        )
+        )(*args, **kwargs)
 
     def lookup_users(self, user_ids=None, screen_names=None, include_entities=None, tweet_mode=None):
-        """ Perform bulk look up of users from user ID or screen_name """
+        """ Perform bulk look up of users from user ID or screen_name
+            :reference: https://dev.twitter.com/rest/reference/get/users/lookup
+            allowed_param='user_id', 'screen_name', 'include_entities', 'tweet_mode'
+        """
         post_data = {}
         if include_entities is not None:
             include_entities = 'true' if include_entities else 'false'
@@ -334,27 +328,19 @@ class API(object):
         if tweet_mode:
             post_data['tweet_mode'] = tweet_mode
 
-        return self._lookup_users(post_data=post_data)
-
-    @property
-    def _lookup_users(self):
-        """ :reference: https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-users-lookup
-            allowed_param='user_id', 'screen_name', 'include_entities', 'tweet_mode'
-        """
         return bind_api(
             api=self,
             path='/users/lookup.json',
             payload_type='user', payload_list=True,
             method='POST',
             allowed_param=['user_id', 'screen_name', 'include_entities', 'tweet_mode']
-        )
+        )(post_data=post_data)
 
-    def me(self):
+    def me(self, *args, **kwargs):
         """ Get the authenticated user """
         return self.get_user(screen_name=self.auth.get_username())
 
-    @property
-    def search_users(self):
+    def search_users(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-users-search
             :allowed_param:'q', 'count', 'page'
         """
@@ -364,10 +350,10 @@ class API(object):
             payload_type='user', payload_list=True,
             require_auth=True,
             allowed_param=['q', 'count', 'page']
-        )
+        )(*args, **kwargs)
+    search_users.pagination_mode = 'page'
 
-    @property
-    def suggested_users(self):
+    def suggested_users(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-users-suggestions-slug
             :allowed_param:'slug', 'lang'
         """
@@ -377,10 +363,9 @@ class API(object):
             payload_type='user', payload_list=True,
             require_auth=True,
             allowed_param=['slug', 'lang']
-        )
+        )(*args, **kwargs)
 
-    @property
-    def suggested_categories(self):
+    def suggested_categories(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-users-suggestions
             :allowed_param:'lang'
         """
@@ -390,10 +375,9 @@ class API(object):
             payload_type='category', payload_list=True,
             allowed_param=['lang'],
             require_auth=True
-        )
+        )(*args, **kwargs)
 
-    @property
-    def suggested_users_tweets(self):
+    def suggested_users_tweets(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-users-suggestions-slug-members
             :allowed_param:'slug'
         """
@@ -403,10 +387,9 @@ class API(object):
             payload_type='status', payload_list=True,
             allowed_param=['slug'],
             require_auth=True
-        )
+        )(*args, **kwargs)
 
-    @property
-    def direct_messages(self):
+    def direct_messages(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/direct-messages/sending-and-receiving/api-reference/get-messages
             :allowed_param:'since_id', 'max_id', 'count', 'full_text'
         """
@@ -416,10 +399,10 @@ class API(object):
             payload_type='direct_message', payload_list=True,
             allowed_param=['since_id', 'max_id', 'count', 'full_text'],
             require_auth=True
-        )
+        )(*args, **kwargs)
+    direct_messages.pagination_mode = 'id'
 
-    @property
-    def get_direct_message(self):
+    def get_direct_message(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/direct-messages/sending-and-receiving/api-reference/get-message
             :allowed_param:'id', 'full_text'
         """
@@ -429,10 +412,9 @@ class API(object):
             payload_type='direct_message',
             allowed_param=['id', 'full_text'],
             require_auth=True
-        )
+        )(*args, **kwargs)
 
-    @property
-    def sent_direct_messages(self):
+    def sent_direct_messages(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/direct-messages/sending-and-receiving/api-reference/get-sent-message
             :allowed_param:'since_id', 'max_id', 'count', 'page', 'full_text'
         """
@@ -442,10 +424,10 @@ class API(object):
             payload_type='direct_message', payload_list=True,
             allowed_param=['since_id', 'max_id', 'count', 'page', 'full_text'],
             require_auth=True
-        )
+        )(*args, **kwargs)
+    sent_direct_messages.pagination_mode = 'id'
 
-    @property
-    def send_direct_message(self):
+    def send_direct_message(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/direct-messages/sending-and-receiving/api-reference/new-message
             :allowed_param:'user', 'screen_name', 'user_id', 'text'
         """
@@ -456,10 +438,9 @@ class API(object):
             payload_type='direct_message',
             allowed_param=['user', 'screen_name', 'user_id', 'text'],
             require_auth=True
-        )
+        )(*args, **kwargs)
 
-    @property
-    def destroy_direct_message(self):
+    def destroy_direct_message(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/direct-messages/sending-and-receiving/api-reference/delete-message
             :allowed_param:'id'
         """
@@ -470,10 +451,9 @@ class API(object):
             payload_type='direct_message',
             allowed_param=['id'],
             require_auth=True
-        )
+        )(*args, **kwargs)
 
-    @property
-    def create_friendship(self):
+    def create_friendship(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/post-friendships-create
             :allowed_param:'id', 'user_id', 'screen_name', 'follow'
         """
@@ -484,10 +464,9 @@ class API(object):
             payload_type='user',
             allowed_param=['id', 'user_id', 'screen_name', 'follow'],
             require_auth=True
-        )
+        )(*args, **kwargs)
 
-    @property
-    def destroy_friendship(self):
+    def destroy_friendship(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/post-friendships-destroy
             :allowed_param:'id', 'user_id', 'screen_name'
         """
@@ -498,10 +477,9 @@ class API(object):
             payload_type='user',
             allowed_param=['id', 'user_id', 'screen_name'],
             require_auth=True
-        )
+        )(*args, **kwargs)
 
-    @property
-    def show_friendship(self):
+    def show_friendship(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-friendships-show
             :allowed_param:'source_id', 'source_screen_name', 'target_id', 'target_screen_name'
         """
@@ -511,15 +489,11 @@ class API(object):
             payload_type='friendship',
             allowed_param=['source_id', 'source_screen_name',
                            'target_id', 'target_screen_name']
-        )
+        )(*args, **kwargs)
 
     def lookup_friendships(self, user_ids=None, screen_names=None):
-        """ Perform bulk look up of friendships from user ID or screenname """
-        return self._lookup_friendships(list_to_csv(user_ids), list_to_csv(screen_names))
-
-    @property
-    def _lookup_friendships(self):
-        """ :reference: https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-friendships-lookup
+        """ Perform bulk look up of friendships from user ID or screenname
+            :reference: https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-friendships-lookup
             :allowed_param:'user_id', 'screen_name'
         """
         return bind_api(
@@ -528,10 +502,9 @@ class API(object):
             payload_type='relationship', payload_list=True,
             allowed_param=['user_id', 'screen_name'],
             require_auth=True
-        )
+        )(list_to_csv(user_ids), list_to_csv(screen_names))
 
-    @property
-    def friends_ids(self):
+    def friends_ids(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-friends-ids
             :allowed_param:'id', 'user_id', 'screen_name', 'cursor'
         """
@@ -540,10 +513,10 @@ class API(object):
             path='/friends/ids.json',
             payload_type='ids',
             allowed_param=['id', 'user_id', 'screen_name', 'cursor']
-        )
+        )(*args, **kwargs)
+    friends_ids.pagination_mode = 'cursor'
 
-    @property
-    def friends(self):
+    def friends(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-friends-list
             :allowed_param:'id', 'user_id', 'screen_name', 'cursor', 'skip_status', 'include_user_entities'
         """
@@ -552,10 +525,10 @@ class API(object):
             path='/friends/list.json',
             payload_type='user', payload_list=True,
             allowed_param=['id', 'user_id', 'screen_name', 'cursor', 'skip_status', 'include_user_entities']
-        )
+        )(*args, **kwargs)
+    friends.pagination_mode = 'cursor'
 
-    @property
-    def friendships_incoming(self):
+    def friendships_incoming(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-friendships-incoming
             :allowed_param:'cursor'
         """
@@ -564,10 +537,10 @@ class API(object):
             path='/friendships/incoming.json',
             payload_type='ids',
             allowed_param=['cursor']
-        )
+        )(*args, **kwargs)
+    friendships_incoming.pagination_mode = 'cursor'
 
-    @property
-    def friendships_outgoing(self):
+    def friendships_outgoing(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-friendships-outgoing
             :allowed_param:'cursor'
         """
@@ -576,10 +549,10 @@ class API(object):
             path='/friendships/outgoing.json',
             payload_type='ids',
             allowed_param=['cursor']
-        )
+        )(*args, **kwargs)
+    friendships_outgoing.pagination_mode = 'cursor'
 
-    @property
-    def followers_ids(self):
+    def followers_ids(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-followers-ids
             :allowed_param:'id', 'user_id', 'screen_name', 'cursor', 'count'
         """
@@ -588,10 +561,10 @@ class API(object):
             path='/followers/ids.json',
             payload_type='ids',
             allowed_param=['id', 'user_id', 'screen_name', 'cursor', 'count']
-        )
+        )(*args, **kwargs)
+    followers_ids.pagination_mode = 'cursor'
 
-    @property
-    def followers(self):
+    def followers(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-followers-list
             :allowed_param:'id', 'user_id', 'screen_name', 'cursor', 'count', 'skip_status', 'include_user_entities'
         """
@@ -601,20 +574,19 @@ class API(object):
             payload_type='user', payload_list=True,
             allowed_param=['id', 'user_id', 'screen_name', 'cursor', 'count',
                            'skip_status', 'include_user_entities']
-        )
+        )(*args, **kwargs)
+    followers.pagination_mode = 'cursor'
 
-    @property
-    def get_settings(self):
+    def get_settings(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/accounts-and-users/manage-account-settings/api-reference/get-account-settings """
         return bind_api(
             api=self,
             path='/account/settings.json',
             payload_type='json',
             use_cache=False
-        )
+        )(*args, **kwargs)
 
-    @property
-    def set_settings(self):
+    def set_settings(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/accounts-and-users/manage-account-settings/api-reference/post-account-settings
             :allowed_param:'sleep_time_enabled', 'start_sleep_time',
             'end_sleep_time', 'time_zone', 'trend_location_woeid',
@@ -630,7 +602,7 @@ class API(object):
                            'trend_location_woeid', 'allow_contributor_request',
                            'lang'],
             use_cache=False
-        )
+        )(*args, **kwargs)
 
     def verify_credentials(self, **kargs):
         """ :reference: https://developer.twitter.com/en/docs/accounts-and-users/manage-account-settings/api-reference/get-account-verify_credentials
@@ -649,8 +621,7 @@ class API(object):
                 return False
             raise
 
-    @property
-    def rate_limit_status(self):
+    def rate_limit_status(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/developer-utilities/rate-limit-status/api-reference/get-application-rate_limit_status
             :allowed_param:'resources'
         """
@@ -660,7 +631,7 @@ class API(object):
             payload_type='json',
             allowed_param=['resources'],
             use_cache=False
-        )
+        )(*args, **kwargs)
 
     def update_profile_image(self, filename, file_=None):
         """ :reference: https://developer.twitter.com/en/docs/accounts-and-users/manage-account-settings/api-reference/post-account-update_profile_image
@@ -705,8 +676,7 @@ class API(object):
             require_auth=True
         )(post_data=post_data, headers=headers)
 
-    @property
-    def update_profile(self):
+    def update_profile(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/accounts-and-users/manage-account-settings/api-reference/post-account-update_profile
             :allowed_param:'name', 'url', 'location', 'description', 'profile_link_color'
         """
@@ -717,10 +687,9 @@ class API(object):
             payload_type='user',
             allowed_param=['name', 'url', 'location', 'description', 'profile_link_color'],
             require_auth=True
-        )
+        )(*args, **kwargs)
 
-    @property
-    def favorites(self):
+    def favorites(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/tweets/post-and-engage/api-reference/get-favorites-list
             :allowed_param:'screen_name', 'user_id', 'max_id', 'count', 'since_id', 'max_id'
         """
@@ -729,10 +698,10 @@ class API(object):
             path='/favorites/list.json',
             payload_type='status', payload_list=True,
             allowed_param=['screen_name', 'user_id', 'max_id', 'count', 'since_id', 'max_id']
-        )
+        )(*args, **kwargs)
+    favorites.pagination_mode = 'id'
 
-    @property
-    def create_favorite(self):
+    def create_favorite(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/tweets/post-and-engage/api-reference/post-favorites-create
             :allowed_param:'id'
         """
@@ -743,10 +712,9 @@ class API(object):
             payload_type='status',
             allowed_param=['id'],
             require_auth=True
-        )
+        )(*args, **kwargs)
 
-    @property
-    def destroy_favorite(self):
+    def destroy_favorite(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/tweets/post-and-engage/api-reference/post-favorites-destroy
             :allowed_param:'id'
         """
@@ -757,10 +725,9 @@ class API(object):
             payload_type='status',
             allowed_param=['id'],
             require_auth=True
-        )
+        )(*args, **kwargs)
 
-    @property
-    def create_block(self):
+    def create_block(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/accounts-and-users/mute-block-report-users/api-reference/post-blocks-create
             :allowed_param:'id', 'user_id', 'screen_name'
         """
@@ -771,10 +738,9 @@ class API(object):
             payload_type='user',
             allowed_param=['id', 'user_id', 'screen_name'],
             require_auth=True
-        )
+        )(*args, **kwargs)
 
-    @property
-    def destroy_block(self):
+    def destroy_block(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/accounts-and-users/mute-block-report-users/api-reference/post-blocks-destroy
             :allowed_param:'id', 'user_id', 'screen_name'
         """
@@ -785,10 +751,9 @@ class API(object):
             payload_type='user',
             allowed_param=['id', 'user_id', 'screen_name'],
             require_auth=True
-        )
+        )(*args, **kwargs)
 
-    @property
-    def mutes_ids(self):
+    def mutes_ids(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/accounts-and-users/mute-block-report-users/api-reference/get-mutes-users-ids
             :allowed_param:'cursor'
         """
@@ -798,10 +763,10 @@ class API(object):
             payload_type='ids',
             allowed_param=['cursor'],
             require_auth=True
-        )
+        )(*args, **kwargs)
+    mutes_ids.pagination_mode = 'cursor'
 
-    @property
-    def create_mute(self):
+    def create_mute(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/accounts-and-users/mute-block-report-users/api-reference/post-mutes-users-create
             :allowed_param:'id', 'user_id', 'screen_name'
         """
@@ -812,10 +777,9 @@ class API(object):
             payload_type='user',
             allowed_param=['id', 'user_id', 'screen_name'],
             require_auth=True
-        )
+        )(*args, **kwargs)
 
-    @property
-    def destroy_mute(self):
+    def destroy_mute(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/accounts-and-users/mute-block-report-users/api-reference/post-mutes-users-destroy
             :allowed_param:'id', 'user_id', 'screen_name'
         """
@@ -826,10 +790,9 @@ class API(object):
             payload_type='user',
             allowed_param=['id', 'user_id', 'screen_name'],
             require_auth=True
-        )
+        )(*args, **kwargs)
 
-    @property
-    def blocks(self):
+    def blocks(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/accounts-and-users/mute-block-report-users/api-reference/get-blocks-list
             :allowed_param:'cursor'
         """
@@ -839,10 +802,10 @@ class API(object):
             payload_type='user', payload_list=True,
             allowed_param=['cursor'],
             require_auth=True
-        )
+        )(*args, **kwargs)
+    blocks.pagination_mode = 'cursor'
 
-    @property
-    def blocks_ids(self):
+    def blocks_ids(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/accounts-and-users/mute-block-report-users/api-reference/get-blocks-ids
             :allowed_param:'cursor'
         """
@@ -852,10 +815,10 @@ class API(object):
             payload_type='ids',
             allowed_param=['cursor'],
             require_auth=True
-        )
+        )(*args, **kwargs)
+    blocks_ids.pagination_mode = 'cursor'
 
-    @property
-    def report_spam(self):
+    def report_spam(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/accounts-and-users/mute-block-report-users/api-reference/post-users-report_spam
             :allowed_param:'user_id', 'screen_name', 'perform_block'
         """
@@ -866,20 +829,18 @@ class API(object):
             payload_type='user',
             allowed_param=['user_id', 'screen_name', 'perform_block'],
             require_auth=True
-        )
+        )(*args, **kwargs)
 
-    @property
-    def saved_searches(self):
+    def saved_searches(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/accounts-and-users/manage-account-settings/api-reference/get-saved_searches-list """
         return bind_api(
             api=self,
             path='/saved_searches/list.json',
             payload_type='saved_search', payload_list=True,
             require_auth=True
-        )
+        )(*args, **kwargs)
 
-    @property
-    def get_saved_search(self):
+    def get_saved_search(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/accounts-and-users/manage-account-settings/api-reference/get-saved_searches-show-id
             :allowed_param:'id'
         """
@@ -889,10 +850,9 @@ class API(object):
             payload_type='saved_search',
             allowed_param=['id'],
             require_auth=True
-        )
+        )(*args, **kwargs)
 
-    @property
-    def create_saved_search(self):
+    def create_saved_search(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/accounts-and-users/manage-account-settings/api-reference/post-saved_searches-create
             :allowed_param:'query'
         """
@@ -903,10 +863,9 @@ class API(object):
             payload_type='saved_search',
             allowed_param=['query'],
             require_auth=True
-        )
+        )(*args, **kwargs)
 
-    @property
-    def destroy_saved_search(self):
+    def destroy_saved_search(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/accounts-and-users/manage-account-settings/api-reference/post-saved_searches-destroy-id
             :allowed_param:'id'
         """
@@ -917,10 +876,9 @@ class API(object):
             payload_type='saved_search',
             allowed_param=['id'],
             require_auth=True
-        )
+        )(*args, **kwargs)
 
-    @property
-    def create_list(self):
+    def create_list(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/post-lists-create
             :allowed_param:'name', 'mode', 'description'
         """
@@ -931,10 +889,9 @@ class API(object):
             payload_type='list',
             allowed_param=['name', 'mode', 'description'],
             require_auth=True
-        )
+        )(*args, **kwargs)
 
-    @property
-    def destroy_list(self):
+    def destroy_list(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/post-lists-destroy
             :allowed_param:'owner_screen_name', 'owner_id', 'list_id', 'slug'
         """
@@ -945,10 +902,9 @@ class API(object):
             payload_type='list',
             allowed_param=['owner_screen_name', 'owner_id', 'list_id', 'slug'],
             require_auth=True
-        )
+        )(*args, **kwargs)
 
-    @property
-    def update_list(self):
+    def update_list(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/post-lists-update
             :allowed_param: list_id', 'slug', 'name', 'mode', 'description', 'owner_screen_name', 'owner_id'
         """
@@ -959,10 +915,9 @@ class API(object):
             payload_type='list',
             allowed_param=['list_id', 'slug', 'name', 'mode', 'description', 'owner_screen_name', 'owner_id'],
             require_auth=True
-        )
+        )(*args, **kwargs)
 
-    @property
-    def lists_all(self):
+    def lists_all(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-list
             :allowed_param:'screen_name', 'user_id'
         """
@@ -972,10 +927,9 @@ class API(object):
             payload_type='list', payload_list=True,
             allowed_param=['screen_name', 'user_id'],
             require_auth=True
-        )
+        )(*args, **kwargs)
 
-    @property
-    def lists_memberships(self):
+    def lists_memberships(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-memberships
             :allowed_param:'screen_name', 'user_id', 'filter_to_owned_lists', 'cursor'
         """
@@ -985,10 +939,10 @@ class API(object):
             payload_type='list', payload_list=True,
             allowed_param=['screen_name', 'user_id', 'filter_to_owned_lists', 'cursor'],
             require_auth=True
-        )
+        )(*args, **kwargs)
+    lists_memberships.pagination_mode = 'cursor'
 
-    @property
-    def lists_subscriptions(self):
+    def lists_subscriptions(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-subscriptions
             :allowed_param:'screen_name', 'user_id', 'cursor'
         """
@@ -998,10 +952,10 @@ class API(object):
             payload_type='list', payload_list=True,
             allowed_param=['screen_name', 'user_id', 'cursor'],
             require_auth=True
-        )
+        )(*args, **kwargs)
+    lists_subscriptions.pagination_mode = 'cursor'
 
-    @property
-    def list_timeline(self):
+    def list_timeline(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-statuses
             :allowed_param:'owner_screen_name', 'slug', 'owner_id', 'list_id',
              'since_id', 'max_id', 'count', 'include_rts
@@ -1013,10 +967,10 @@ class API(object):
             allowed_param=['owner_screen_name', 'slug', 'owner_id',
                            'list_id', 'since_id', 'max_id', 'count',
                            'include_rts']
-        )
+        )(*args, **kwargs)
+    list_timeline.pagination_mode = 'id'
 
-    @property
-    def get_list(self):
+    def get_list(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-show
             :allowed_param:'owner_screen_name', 'owner_id', 'slug', 'list_id'
         """
@@ -1025,10 +979,9 @@ class API(object):
             path='/lists/show.json',
             payload_type='list',
             allowed_param=['owner_screen_name', 'owner_id', 'slug', 'list_id']
-        )
+        )(*args, **kwargs)
 
-    @property
-    def add_list_member(self):
+    def add_list_member(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/post-lists-members-create
             :allowed_param:'screen_name', 'user_id', 'owner_screen_name',
              'owner_id', 'slug', 'list_id'
@@ -1041,10 +994,9 @@ class API(object):
             allowed_param=['screen_name', 'user_id', 'owner_screen_name',
                            'owner_id', 'slug', 'list_id'],
             require_auth=True
-        )
+        )(*args, **kwargs)
 
-    @property
-    def remove_list_member(self):
+    def remove_list_member(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/post-lists-members-destroy
             :allowed_param:'screen_name', 'user_id', 'owner_screen_name',
              'owner_id', 'slug', 'list_id'
@@ -1057,7 +1009,7 @@ class API(object):
             allowed_param=['screen_name', 'user_id', 'owner_screen_name',
                            'owner_id', 'slug', 'list_id'],
             require_auth=True
-        )
+        )(*args, **kwargs)
 
     def add_list_members(self, screen_name=None, user_id=None, slug=None,
                          list_id=None, owner_id=None, owner_screen_name=None):
@@ -1067,8 +1019,7 @@ class API(object):
                                       slug, list_id, owner_id,
                                       owner_screen_name)
 
-    @property
-    def _add_list_members(self):
+    def _add_list_members(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/post-lists-members-create_all
             :allowed_param:'screen_name', 'user_id', 'slug', 'list_id',
             'owner_id', 'owner_screen_name'
@@ -1082,7 +1033,7 @@ class API(object):
             allowed_param=['screen_name', 'user_id', 'slug', 'list_id',
                            'owner_id', 'owner_screen_name'],
             require_auth=True
-        )
+        )(*args, **kwargs)
 
     def remove_list_members(self, screen_name=None, user_id=None, slug=None,
                             list_id=None, owner_id=None, owner_screen_name=None):
@@ -1092,8 +1043,7 @@ class API(object):
                                          slug, list_id, owner_id,
                                          owner_screen_name)
 
-    @property
-    def _remove_list_members(self):
+    def _remove_list_members(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/post-lists-members-destroy_all
             :allowed_param:'screen_name', 'user_id', 'slug', 'list_id',
             'owner_id', 'owner_screen_name'
@@ -1107,10 +1057,9 @@ class API(object):
             allowed_param=['screen_name', 'user_id', 'slug', 'list_id',
                            'owner_id', 'owner_screen_name'],
             require_auth=True
-        )
+        )(*args, **kwargs)
 
-    @property
-    def list_members(self):
+    def list_members(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-members
             :allowed_param:'owner_screen_name', 'slug', 'list_id',
              'owner_id', 'cursor
@@ -1121,10 +1070,10 @@ class API(object):
             payload_type='user', payload_list=True,
             allowed_param=['owner_screen_name', 'slug', 'list_id',
                            'owner_id', 'cursor']
-        )
+        )(*args, **kwargs)
+    list_members.pagination_mode = 'cursor'
 
-    @property
-    def show_list_member(self):
+    def show_list_member(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-members-show
             :allowed_param:'list_id', 'slug', 'user_id', 'screen_name',
              'owner_screen_name', 'owner_id
@@ -1135,10 +1084,9 @@ class API(object):
             payload_type='user',
             allowed_param=['list_id', 'slug', 'user_id', 'screen_name',
                            'owner_screen_name', 'owner_id']
-        )
+        )(*args, **kwargs)
 
-    @property
-    def subscribe_list(self):
+    def subscribe_list(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/post-lists-subscribers-create
             :allowed_param:'owner_screen_name', 'slug', 'owner_id',
             'list_id'
@@ -1151,10 +1099,9 @@ class API(object):
             allowed_param=['owner_screen_name', 'slug', 'owner_id',
                            'list_id'],
             require_auth=True
-        )
+        )(*args, **kwargs)
 
-    @property
-    def unsubscribe_list(self):
+    def unsubscribe_list(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/post-lists-subscribers-destroy
             :allowed_param:'owner_screen_name', 'slug', 'owner_id',
             'list_id'
@@ -1167,10 +1114,9 @@ class API(object):
             allowed_param=['owner_screen_name', 'slug', 'owner_id',
                            'list_id'],
             require_auth=True
-        )
+        )(*args, **kwargs)
 
-    @property
-    def list_subscribers(self):
+    def list_subscribers(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-subscribers
             :allowed_param:'owner_screen_name', 'slug', 'owner_id',
              'list_id', 'cursor
@@ -1181,10 +1127,10 @@ class API(object):
             payload_type='user', payload_list=True,
             allowed_param=['owner_screen_name', 'slug', 'owner_id',
                            'list_id', 'cursor']
-        )
+        )(*args, **kwargs)
+    list_subscribers.pagination_mode = 'cursor'
 
-    @property
-    def show_list_subscriber(self):
+    def show_list_subscriber(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-subscribers-show
             :allowed_param:'owner_screen_name', 'slug', 'screen_name',
              'owner_id', 'list_id', 'user_id
@@ -1195,19 +1141,17 @@ class API(object):
             payload_type='user',
             allowed_param=['owner_screen_name', 'slug', 'screen_name',
                            'owner_id', 'list_id', 'user_id']
-        )
+        )(*args, **kwargs)
 
-    @property
-    def trends_available(self):
+    def trends_available(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/trends/locations-with-trending-topics/api-reference/get-trends-available """
         return bind_api(
             api=self,
             path='/trends/available.json',
             payload_type='json'
-        )
+        )(*args, **kwargs)
 
-    @property
-    def trends_place(self):
+    def trends_place(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/trends/trends-for-location/api-reference/get-trends-place
             :allowed_param:'id', 'exclude'
         """
@@ -1216,10 +1160,9 @@ class API(object):
             path='/trends/place.json',
             payload_type='json',
             allowed_param=['id', 'exclude']
-        )
+        )(*args, **kwargs)
 
-    @property
-    def trends_closest(self):
+    def trends_closest(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/trends/locations-with-trending-topics/api-reference/get-trends-closest
             :allowed_param:'lat', 'long'
         """
@@ -1228,10 +1171,9 @@ class API(object):
             path='/trends/closest.json',
             payload_type='json',
             allowed_param=['lat', 'long']
-        )
+        )(*args, **kwargs)
 
-    @property
-    def search(self):
+    def search(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/tweets/search/api-reference/get-search-tweets
             :allowed_param:'q', 'lang', 'locale', 'since_id', 'geocode',
              'max_id', 'since', 'until', 'result_type', 'count',
@@ -1245,10 +1187,10 @@ class API(object):
                            'max_id', 'since', 'until', 'result_type',
                            'count', 'include_entities', 'from',
                            'to', 'source']
-        )
+        )(*args, **kwargs)
+    search.pagination_mode = 'id'
 
-    @property
-    def reverse_geocode(self):
+    def reverse_geocode(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/geo/places-near-location/api-reference/get-geo-reverse_geocode
             :allowed_param:'lat', 'long', 'accuracy', 'granularity', 'max_results'
         """
@@ -1258,10 +1200,9 @@ class API(object):
             payload_type='place', payload_list=True,
             allowed_param=['lat', 'long', 'accuracy', 'granularity',
                            'max_results']
-        )
+        )(*args, **kwargs)
 
-    @property
-    def geo_id(self):
+    def geo_id(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/geo/place-information/api-reference/get-geo-id-place_id
             :allowed_param:'id'
         """
@@ -1270,10 +1211,9 @@ class API(object):
             path='/geo/id/{id}.json',
             payload_type='place',
             allowed_param=['id']
-        )
+        )(*args, **kwargs)
 
-    @property
-    def geo_search(self):
+    def geo_search(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/geo/places-near-location/api-reference/get-geo-search
             :allowed_param:'lat', 'long', 'query', 'ip', 'granularity',
              'accuracy', 'max_results', 'contained_within
@@ -1285,10 +1225,9 @@ class API(object):
             payload_type='place', payload_list=True,
             allowed_param=['lat', 'long', 'query', 'ip', 'granularity',
                            'accuracy', 'max_results', 'contained_within']
-        )
+        )(*args, **kwargs)
 
-    @property
-    def geo_similar_places(self):
+    def geo_similar_places(self, *args, **kwargs):
         """ :reference: https://dev.twitter.com/rest/reference/get/geo/similar_places
             :allowed_param:'lat', 'long', 'name', 'contained_within'
         """
@@ -1297,27 +1236,25 @@ class API(object):
             path='/geo/similar_places.json',
             payload_type='place', payload_list=True,
             allowed_param=['lat', 'long', 'name', 'contained_within']
-        )
+        )(*args, **kwargs)
 
-    @property
-    def supported_languages(self):
+    def supported_languages(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/developer-utilities/supported-languages/api-reference/get-help-languages """
         return bind_api(
             api=self,
             path='/help/languages.json',
             payload_type='json',
             require_auth=True
-        )
+        )(*args, **kwargs)
 
-    @property
-    def configuration(self):
+    def configuration(self, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/developer-utilities/configuration/api-reference/get-help-configuration """
         return bind_api(
             api=self,
             path='/help/configuration.json',
             payload_type='json',
             require_auth=True
-        )
+        )(*args, **kwargs)
 
     """ Internal use only """
 

--- a/tweepy/binder.py
+++ b/tweepy/binder.py
@@ -246,13 +246,4 @@ def bind_api(**config):
         else:
             return method.execute()
 
-    # Set pagination mode
-    if 'cursor' in APIMethod.allowed_param:
-        _call.pagination_mode = 'cursor'
-    elif 'max_id' in APIMethod.allowed_param:
-        if 'since_id' in APIMethod.allowed_param:
-            _call.pagination_mode = 'id'
-    elif 'page' in APIMethod.allowed_param:
-        _call.pagination_mode = 'page'
-
     return _call


### PR DESCRIPTION
…y decorators from some of the member functions, which are not actually property descriptors.

Consolidate function docs for legacy _lookup_users() _lookup_users() functions, which can now be removed given the way bind_api has been used since 2014, which also improves help() for them.

This also makes the nature of pagination more obvious and explicit.