### PR TITLE
Test on Python 3.8 beta to avoid surprises

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ matrix:
   include:
     - python: 3.7
       dist: xenial
+    - python: 3.8-dev
+      dist: xenial
 
 env:
   global:


### PR DESCRIPTION
Python 3.8 is in beta and due for release on 2019-10-21.

* https://www.python.org/dev/peps/pep-0569/#schedule

Now is a good to time to start testing on Python 3.8 to make sure there are no surprises when it is released.
