### PR TITLE
Add DMCursorIterator

### DIFF
--- a/tweepy/binder.py
+++ b/tweepy/binder.py
@@ -55,6 +55,7 @@ def bind_api(**config):
                                                  api.wait_on_rate_limit)
             self.wait_on_rate_limit_notify = kwargs.pop('wait_on_rate_limit_notify',
                                                         api.wait_on_rate_limit_notify)
+            self.return_cursors = kwargs.pop('return_cursors', False)
             self.parser = kwargs.pop('parser', api.parser)
             self.session.headers = kwargs.pop('headers', {})
             self.build_parameters(args, kwargs)
@@ -233,7 +234,8 @@ def bind_api(**config):
                     raise TweepError(error_msg, resp, api_code=api_error_code)
 
             # Parse the response payload
-            result = self.parser.parse(self, resp.text)
+            self.return_cursors = self.return_cursors or 'cursor' in self.session.params
+            result = self.parser.parse(self, resp.text, return_cursors=self.return_cursors)
 
             # Store result into cache if one is available.
             if self.use_cache and self.api.cache and self.method == 'GET' and result:

--- a/tweepy/binder.py
+++ b/tweepy/binder.py
@@ -253,7 +253,10 @@ def bind_api(**config):
 
     # Set pagination mode
     if 'cursor' in APIMethod.allowed_param:
-        _call.pagination_mode = 'cursor'
+        if APIMethod.payload_type == 'direct_message':
+            _call.pagination_mode = 'dm_cursor'
+        else:
+            _call.pagination_mode = 'cursor'
     elif 'max_id' in APIMethod.allowed_param:
         if 'since_id' in APIMethod.allowed_param:
             _call.pagination_mode = 'id'

--- a/tweepy/cursor.py
+++ b/tweepy/cursor.py
@@ -217,6 +217,8 @@ class ItemIterator(BaseIterator):
         if self.current_page is None or self.page_index == len(self.current_page) - 1:
             # Reached end of current page, get the next page...
             self.current_page = self.page_iterator.next()
+            while len(self.current_page) == 0:
+                self.current_page = self.page_iterator.next()
             self.page_index = -1
         self.page_index += 1
         self.num_tweets += 1

--- a/tweepy/cursor.py
+++ b/tweepy/cursor.py
@@ -99,7 +99,7 @@ class DMCursorIterator(BaseIterator):
     def next(self):
         if self.next_cursor == -1 or (self.limit and self.page_count == self.limit):
             raise StopIteration
-        data = self.method(cursor=self.next_cursor, *self.args, **self.kwargs)
+        data = self.method(cursor=self.next_cursor, return_cursors=True, *self.args, **self.kwargs)
         self.page_count += 1
         if isinstance(data, tuple):
             data, self.next_cursor = data


### PR DESCRIPTION
It seems that pagination for the [GET direct_messages/events/list endpoint](https://developer.twitter.com/en/docs/direct-messages/sending-and-receiving/api-reference/list-events) does not follow the same [documented cursoring technique](https://developer.twitter.com/en/docs/basics/cursoring) for Twitter's REST API, resulting in #1261.

Currently the library attempts to pass `-1` as `cursor` in the initial request, per the documentation:
> To retrieve cursored results, you initially pass a `cursor` with a value of `-1` to the endpoint.

This results in the error in #1261, as the endpoint does not accept `-1` as `cursor` and instead expects no initial `cursor` parameter.

The endpoint also only provides a single `next_cursor` property in the returned data. This means that backwards pagination is not possible with the endpoint.

To resolve this issue and fix #1261, this pull request adds a new `DMCursorIterator` to be used when a `Cursor` is used with `API.list_direct_messages`.

It also adds handling of empty pages to `ItemIterator`, for when using `Cursor.items` with `API.list_direct_messages`, as per the documentation:
> In rare cases the events array may be empty.

(In my testing, the endpoint was adding an additional page with no results.)

Additionally, since the current method `JSONParser.parse` uses to determine whether to return cursors for `Cursor` is to check the requests session parameters, `requests.Session.params`, for `'cursor'`, it is unable to do so with `API.list_direct_messages`, since the `cursor` parameter is not passed in the initial request. In fact, there is currently no way for the parse method of any parser to determine whether `API.list_direct_messages` is being used from a `Cursor` or not.

In order to resolve this, a `return_cursors` kwarg and attribute, used to explicitly specify to return cursors with the result, is added to `APIMethod`. The existing check for the cursor session parameter is refactored from `JSONParser.parse` to `APIMethod.execute`. This means that the parser's parse method is called with a `return_cursors` kwarg. All parsers in the library are updated to reflect this change, and any custom parsers will need to accept/handle this kwarg.