### PR TITLE
Updated streaming doc so that the example works

### DIFF
--- a/docs/streaming_how_to.rst
+++ b/docs/streaming_how_to.rst
@@ -67,7 +67,7 @@ We need an api to stream. See :ref:`auth_tutorial` to learn how to get an api ob
 Once we have an api and a status listener we can create our stream object.::
 
   myStreamListener = MyStreamListener()
-  myStream = tweepy.Stream(auth = api.auth, listener=myStreamListener)
+  myStream = tweepy.Stream(auth = api.auth, listener=myStreamListener())
 
 Step 3: Starting a Stream
 =========================


### PR DESCRIPTION
I've changed this line:
myStream = tweepy.Stream(auth = api.auth, listener=myStreamListener)
to this:
myStream = tweepy.Stream(auth = api.auth, listener=myStreamListener())
since without () the streaming process did not work, an exception was threw: 
on_exception() missing 1 required positional argument: exception'

It also has an open StackOverflow question:
https://stackoverflow.com/questions/56286483/how-to-fix-on-exception-missing-1-required-positional-argument-exception/58059706#58059706