### PR TITLE
🐛 Bugfix when checking None mimetypes

### DIFF
--- a/tweepy/api.py
+++ b/tweepy/api.py
@@ -1379,9 +1379,9 @@ class API(object):
 
         # image must be gif, jpeg, or png
         file_type = mimetypes.guess_type(filename)
+        file_type = file_type[0]
         if file_type is None:
             raise TweepError('Could not determine file type')
-        file_type = file_type[0]
         if file_type not in ['image/gif', 'image/jpeg', 'image/png']:
             raise TweepError('Invalid file type for image: %s' % file_type)
 


### PR DESCRIPTION
When mimetypes.guess_type encounters a type it is unfamiliar with,
it returns the tuple (None, None). In api.py, when we check for an
unrecognized filetype, it is before the assignment
`file_type = file_type[0]`. As a result, this block always passes,
even when an unrecognized filetype is encountered.

This change hoists the file_type assignment to the first value of the
tuple a few lines higher to remedy the issue.