### PR TITLE
Use pip's git+url syntax for installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ GitHub and install it manually:
     cd tweepy
     python setup.py install
 
+You may also install Tweepy directly from the GitHub 
+repository using pip:
+
+    pip install git+https://github.com/tweepy/tweepy.git
+
+
 Python 2.7, 3.5, 3.6, 3.7, & 3.8 are supported.
 
 Community

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -7,7 +7,4 @@ Install from PyPI::
 
 Install from source::
 
-    git clone git://github.com/tweepy/tweepy.git
-    cd tweepy
-    python setup.py install
-
+    pip install git+https://github.com/tweepy/tweepy.git


### PR DESCRIPTION
This is better, as it does not use the easy install program that `python setup.py install` uses