### PR TITLE
Increase max image size for gif

### DIFF
--- a/tweepy/api.py
+++ b/tweepy/api.py
@@ -222,7 +222,7 @@ class API(object):
 
         file_type = imghdr.what(filename)
         if file_type == 'gif':
-            max_size = 14648
+            max_size = 14649
         else:
             max_size = 4883
 

--- a/tweepy/api.py
+++ b/tweepy/api.py
@@ -219,7 +219,14 @@ class API(object):
             :allowed_param:
         """
         f = kwargs.pop('file', None)
-        headers, post_data = API._pack_image(filename, 4883,
+
+        file_type = imghdr.what(filename)
+        if file_type == 'gif':
+            max_size = 15360
+        else:
+            max_size = 4883
+
+        headers, post_data = API._pack_image(filename, max_size,
                                              form_field='media', f=f)
         kwargs.update({'headers': headers, 'post_data': post_data})
 

--- a/tweepy/api.py
+++ b/tweepy/api.py
@@ -227,7 +227,8 @@ class API(object):
             max_size = 4883
 
         headers, post_data = API._pack_image(filename, max_size,
-                                             form_field='media', f=f)
+                                             form_field='media', f=f,
+                                             file_type=file_type)
         kwargs.update({'headers': headers, 'post_data': post_data})
 
         return bind_api(
@@ -1363,7 +1364,7 @@ class API(object):
     """ Internal use only """
 
     @staticmethod
-    def _pack_image(filename, max_size, form_field='image', f=None):
+    def _pack_image(filename, max_size, form_field='image', f=None, file_type=None):
         """Pack image from file into multipart-formdata post body"""
         # image must be less than 700kb in size
         if f is None:
@@ -1385,7 +1386,8 @@ class API(object):
             fp = f
 
         # image must be gif, jpeg, png, webp
-        file_type = imghdr.what(filename)
+        if not file_type:
+            file_type = imghdr.what(filename)
         if file_type is None:
             raise TweepError('Could not determine file type')
         if file_type not in ['gif', 'jpeg', 'png', 'webp']:

--- a/tweepy/api.py
+++ b/tweepy/api.py
@@ -222,7 +222,7 @@ class API(object):
 
         file_type = imghdr.what(filename)
         if file_type == 'gif':
-            max_size = 15360
+            max_size = 14648
         else:
             max_size = 4883
 


### PR DESCRIPTION
Raises the maximum size of gifs allowed to 15MB per [Twitter's documentaion](https://developer.twitter.com/en/docs/media/upload-media/overview).

This resolves https://github.com/tweepy/tweepy/issues/1336

**Note:** I set the max size to 15360KB (15 MB). I noticed that the max size for images was slightly less than 5 MB though (4883KB). I couldn't find the reason for that, but if there is one I can revise the size for gifs as well.