### PR TITLE
Fixed broken encoding for track param for Stream

### DIFF
--- a/tweepy/streaming.py
+++ b/tweepy/streaming.py
@@ -267,7 +267,7 @@ class Stream(object):
                 resp = self.session.request('POST',
                                             url,
                                             data=urllib.parse.urlencode(
-                                                self.body, quote_via=urllib.parse.quote),,
+                                                self.body, quote_via=urllib.parse.quote),
                                             timeout=self.timeout,
                                             stream=True,
                                             auth=auth,

--- a/tweepy/streaming.py
+++ b/tweepy/streaming.py
@@ -12,6 +12,7 @@ import re
 import requests
 import ssl
 import sys
+import urllib
 from threading import Thread
 from time import sleep
 
@@ -265,7 +266,8 @@ class Stream(object):
                 auth = self.auth.apply_auth()
                 resp = self.session.request('POST',
                                             url,
-                                            data=self.body,
+                                            data=urllib.parse.urlencode(
+                                                self.body, quote_via=urllib.parse.quote),,
                                             timeout=self.timeout,
                                             stream=True,
                                             auth=auth,


### PR DESCRIPTION
By default, requests use the quote_plus() encoding method which breaks Twitter API filtering with track param.
So instead + we need to use %20 encoding for space.