### PR TITLE
Passing error code to RateLimitError for backwards compatibility with TweepError

### DIFF
--- a/tweepy/binder.py
+++ b/tweepy/binder.py
@@ -228,8 +228,8 @@ def bind_api(**config):
                     error_msg = "Twitter error response: status code = %s" % resp.status_code
                     api_error_code = None
 
-                if is_rate_limit_error_message(error_msg):
-                    raise RateLimitError(error_msg, resp)
+                if is_rate_limit_error_message(api_error_code):
+                    raise RateLimitError(error_msg, resp, api_code=api_error_code)
                 else:
                     raise TweepError(error_msg, resp, api_code=api_error_code)
 

--- a/tweepy/error.py
+++ b/tweepy/error.py
@@ -18,12 +18,9 @@ class TweepError(Exception):
         return self.reason
 
 
-def is_rate_limit_error_message(message):
-    """Check if the supplied error message belongs to a rate limit error."""
-    return isinstance(message, list) \
-        and len(message) > 0 \
-        and 'code' in message[0] \
-        and message[0]['code'] == 88
+def is_rate_limit_error_message(api_error_code):
+    """Check if the supplied error code belongs to a rate limit error."""
+    return api_error_code == 88
 
 
 class RateLimitError(TweepError):


### PR DESCRIPTION
As it's right now, whenever an API operation hits the rate limit Tweepy raises a `tweepy.error.RateLimitError`, although this error is meant to be fully backwards compatible with `TweepError` the `api_code` property is always null. 

With this pull request merged, a `tweepy.error.RateLimitError` will include the error code in the `api_code` property. 

This pull request also makes easier to check if the error was raised because the operation hit the rate limit by passing to `tweepy.error.is_rate_limit_error_message` the api error code previously parsed.