### PR TITLE
Added support for `stringify_ids` param in followers_ids method

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -480,7 +480,7 @@ Friendship Methods
    :rtype: list of Integers
 
 
-.. method:: API.followers_ids(id/screen_name/user_id)
+.. method:: API.followers_ids(id/screen_name/user_id, [cursor], [stringify_ids])
 
    Returns an array containing the IDs of users following the specified user.
 
@@ -488,6 +488,7 @@ Friendship Methods
    :param screen_name: |screen_name|
    :param user_id: |user_id|
    :param cursor: |cursor|
+   :param stringify_ids: Set to true to have ids returned as strings instead. Defaults to false.
    :rtype: list of Integers
 
 

--- a/tweepy/api.py
+++ b/tweepy/api.py
@@ -591,13 +591,13 @@ class API(object):
     @property
     def followers_ids(self):
         """ :reference: https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-followers-ids
-            :allowed_param: 'id', 'user_id', 'screen_name', 'cursor', 'count'
+            :allowed_param: 'id', 'user_id', 'screen_name', 'cursor', 'stringify_ids', 'count'
         """
         return bind_api(
             api=self,
             path='/followers/ids.json',
             payload_type='ids',
-            allowed_param=['id', 'user_id', 'screen_name', 'cursor', 'count']
+            allowed_param=['id', 'user_id', 'screen_name', 'cursor', 'stringify_ids', 'count']
         )
 
     @property


### PR DESCRIPTION
See [Twitter doc page](https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-followers-ids) for more details.