### PR TITLE
Improvements to Relationship Model and documentation for API.lookup_f…

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -468,6 +468,18 @@ Friendship Methods
    :rtype: :class:`Friendship` object
 
 
+.. method:: API.lookup_friendships([user_ids], [screen_names])
+
+   Returns the relationships of the authenticated user to the list of up to
+   100 screen_names or user_ids provided.
+
+   :param user_ids: A list of user IDs, up to 100 are allowed in a single
+                    request.
+   :param screen_names: A list of screen names, up to 100 are allowed in a
+                        single request.
+   :rtype: :class:`Relationship` object
+
+
 .. method:: API.friends_ids(id/screen_name/user_id, [cursor])
 
    Returns an array containing the IDs of users being followed by the specified

--- a/tweepy/models.py
+++ b/tweepy/models.py
@@ -399,6 +399,10 @@ class Relationship(Model):
             if k == 'connections':
                 setattr(result, 'is_following', 'following' in v)
                 setattr(result, 'is_followed_by', 'followed_by' in v)
+                setattr(result, 'is_muted', 'muting' in v)
+                setattr(result, 'is_blocked', 'blocking' in v)
+                setattr(result, 'is_following_requested', 'following_requested' in v)
+                setattr(result, 'no_relationship', 'none' in v)
             else:
                 setattr(result, k, v)
         return result


### PR DESCRIPTION
Improved the Relationship Model as it was lacking some values that comes from the twitter api response as you could see here: 
[API Reference](https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-friendships-lookup)

Also realised we didn't have documentation for the API.lookup_friendships method so I also added that there.