### PR TITLE
Fixes #1412

### DIFF
--- a/tweepy/api.py
+++ b/tweepy/api.py
@@ -220,10 +220,12 @@ class API(object):
             :allowed_param:
         """
         f = kwargs.pop('file', None)
-        h = None
-        if f:
-            h = f.read(32)
 
+        h = None
+        if f is not None:
+            location = f.tell()
+            h = f.read(32)
+            f.seek(location)
         file_type = imghdr.what(filename, h=h) or mimetypes.guess_type(filename)[0]
         if file_type == 'gif':
             max_size = 14649

--- a/tweepy/api.py
+++ b/tweepy/api.py
@@ -220,7 +220,9 @@ class API(object):
             :allowed_param:
         """
         f = kwargs.pop('file', None)
-        h = f.read(32)
+        h = None
+        if f:
+            h = f.read(32)
 
         file_type = imghdr.what(filename, h=h) or mimetypes.guess_type(filename)[0]
         if file_type == 'gif':

--- a/tweepy/api.py
+++ b/tweepy/api.py
@@ -220,8 +220,9 @@ class API(object):
             :allowed_param:
         """
         f = kwargs.pop('file', None)
+        h = f.read(32)
 
-        file_type = imghdr.what(filename, f) or mimetypes.guess_type(filename)[0]
+        file_type = imghdr.what(filename, h=h) or mimetypes.guess_type(filename)[0]
         if file_type == 'gif':
             max_size = 14649
         else:

--- a/tweepy/api.py
+++ b/tweepy/api.py
@@ -221,7 +221,7 @@ class API(object):
         """
         f = kwargs.pop('file', None)
 
-        file_type = imghdr.what(filename) or mimetypes.guess_type(filename)[0]
+        file_type = imghdr.what(filename, f) or mimetypes.guess_type(filename)[0]
         if file_type == 'gif':
             max_size = 14649
         else:


### PR DESCRIPTION
Fixes #1412 by transforming file argument to bytes and passing to `imghdr.what` in `api.media_upload`