### PR TITLE
Updating banner frontend

### DIFF
--- a/tweepy/api.py
+++ b/tweepy/api.py
@@ -708,7 +708,7 @@ class API(object):
         headers, post_data = API._pack_image(filename, 800, f=f)
         return bind_api(
             api=self,
-            path='/account/update_profile_background_image.json',
+            path='/account/update_profile_banner.json',
             method='POST',
             payload_type='user',
             allowed_param=['tile', 'include_entities', 'skip_status', 'use'],


### PR DESCRIPTION
The banner front end has been changed to https://api.twitter.com/1.1/account/update_profile_banner.json as you can see here: https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/manage-account-settings/api-reference/post-account-update_profile_banner