### PR TITLE
Allows media upload from BytesIO

### DIFF
--- a/tweepy/api.py
+++ b/tweepy/api.py
@@ -225,6 +225,8 @@ class API(object):
             file_type = imghdr.what(filename) or mimetypes.guess_type(filename)[0]
         else:
             file_type = imghdr.what(filename, h=f.read()) or mimetypes.guess_type(filename)[0]
+            f.seek(0)  # Reset to beginning of file
+
         if file_type == 'gif':
             max_size = 14649
         else:
@@ -1425,6 +1427,8 @@ class API(object):
                 file_type = imghdr.what(filename) or mimetypes.guess_type(filename)[0]
             else:
                 file_type = imghdr.what(filename, h=f.read()) or mimetypes.guess_type(filename)[0]
+                f.seek(0)  # Reset to beginning of file
+
         if file_type is None:
             raise TweepError('Could not determine file type')
         if file_type in ['gif', 'jpeg', 'png', 'webp']:

--- a/tweepy/api.py
+++ b/tweepy/api.py
@@ -1423,12 +1423,11 @@ class API(object):
 
         # image must be gif, jpeg, png, webp
         if not file_type:
-            if f is None:
-                file_type = imghdr.what(filename) or mimetypes.guess_type(filename)[0]
-            else:
-                file_type = imghdr.what(filename, h=f.read()) or mimetypes.guess_type(filename)[0]
-                f.seek(0)  # Reset to beginning of file
-
+            h = None
+            if f is not None:
+                h = f.read(32)
+                f.seek(0)
+            file_type = imghdr.what(filename, h=h) or mimetypes.guess_type(filename)[0]
         if file_type is None:
             raise TweepError('Could not determine file type')
         if file_type in ['gif', 'jpeg', 'png', 'webp']:

--- a/tweepy/api.py
+++ b/tweepy/api.py
@@ -221,7 +221,10 @@ class API(object):
         """
         f = kwargs.pop('file', None)
 
-        file_type = imghdr.what(filename, h=f.read()) or mimetypes.guess_type(filename)[0]
+        if f is None:
+            file_type = imghdr.what(filename) or mimetypes.guess_type(filename)[0]
+        else:
+            file_type = imghdr.what(filename, h=f.read()) or mimetypes.guess_type(filename)[0]
         if file_type == 'gif':
             max_size = 14649
         else:
@@ -1418,7 +1421,10 @@ class API(object):
 
         # image must be gif, jpeg, png, webp
         if not file_type:
-            file_type = imghdr.what(filename, h=f.read()) or mimetypes.guess_type(filename)[0]
+            if f is None:
+                file_type = imghdr.what(filename) or mimetypes.guess_type(filename)[0]
+            else:
+                file_type = imghdr.what(filename, h=f.read()) or mimetypes.guess_type(filename)[0]
         if file_type is None:
             raise TweepError('Could not determine file type')
         if file_type in ['gif', 'jpeg', 'png', 'webp']:

--- a/tweepy/api.py
+++ b/tweepy/api.py
@@ -221,7 +221,7 @@ class API(object):
         """
         f = kwargs.pop('file', None)
 
-        file_type = imghdr.what(filename) or mimetypes.guess_type(filename)[0]
+        file_type = imghdr.what(filename, h=f.read()) or mimetypes.guess_type(filename)[0]
         if file_type == 'gif':
             max_size = 14649
         else:
@@ -828,7 +828,7 @@ class API(object):
             allowed_param=['cursor'],
             require_auth=True
         )
-    
+
     @property
     def mutes(self):
         """ :reference: https://developer.twitter.com/en/docs/accounts-and-users/mute-block-report-users/api-reference/get-mutes-users-list
@@ -841,7 +841,7 @@ class API(object):
             allowed_param=['cursor', 'include_entities', 'skip_status'],
             required_auth=True
         )
-           
+
 
     @property
     def create_mute(self):
@@ -1288,7 +1288,7 @@ class API(object):
                            'max_id', 'until', 'result_type', 'count',
                            'include_entities']
         )
-    
+
     @pagination(mode='next')
     def search_30_day(self, environment_name, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/tweets/search/api-reference/premium-search
@@ -1303,7 +1303,7 @@ class API(object):
                            'next'],
             require_auth=True
         )(*args, **kwargs)
-    
+
     @pagination(mode='next')
     def search_full_archive(self, environment_name, *args, **kwargs):
         """ :reference: https://developer.twitter.com/en/docs/tweets/search/api-reference/premium-search
@@ -1418,7 +1418,7 @@ class API(object):
 
         # image must be gif, jpeg, png, webp
         if not file_type:
-            file_type = imghdr.what(filename, h=f) or mimetypes.guess_type(filename)[0]
+            file_type = imghdr.what(filename, h=f.read()) or mimetypes.guess_type(filename)[0]
         if file_type is None:
             raise TweepError('Could not determine file type')
         if file_type in ['gif', 'jpeg', 'png', 'webp']:

--- a/tweepy/api.py
+++ b/tweepy/api.py
@@ -1418,7 +1418,7 @@ class API(object):
 
         # image must be gif, jpeg, png, webp
         if not file_type:
-            file_type = imghdr.what(filename) or mimetypes.guess_type(filename)[0]
+            file_type = imghdr.what(filename, h=f) or mimetypes.guess_type(filename)[0]
         if file_type is None:
             raise TweepError('Could not determine file type')
         if file_type in ['gif', 'jpeg', 'png', 'webp']:


### PR DESCRIPTION
Allows the `media_upload()` and `_pack_image()` functions to guess the file type from BytesIO data. All this does is pass in the already-existing `file`/`f` parameters to `imghdr` to guess the file type and allow the data to be processed as if it were a file.