### PR TITLE
docs: fix simple typo, mulitpart -> multipart

### DIFF
--- a/tweepy/api.py
+++ b/tweepy/api.py
@@ -1395,7 +1395,7 @@ class API(object):
             except os.error as e:
                 raise TweepError('Unable to access file: %s' % e.strerror)
 
-            # build the mulitpart-formdata body
+            # build the multipart-formdata body
             fp = open(filename, 'rb')
         else:
             f.seek(0, 2)  # Seek to end of file

--- a/tweepy/cache.py
+++ b/tweepy/cache.py
@@ -363,7 +363,7 @@ class RedisCache(Cache):
 
     def count(self):
         """Note: This is not very efficient,
-        since it retreives all the keys from the redis
+        since it retrieves all the keys from the redis
         server to know how many keys we have"""
         return len(self.client.smembers(self.keys_container))
 


### PR DESCRIPTION
There is a small typo in tweepy/api.py.

Should read `multipart` rather than `mulitpart`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md