### PR TITLE
Make API.verify_credentials() return False instead of throwing if consumer_key is None

### DIFF
--- a/tweepy/api.py
+++ b/tweepy/api.py
@@ -664,6 +664,10 @@ class API:
         """ :reference: https://developer.twitter.com/en/docs/accounts-and-users/manage-account-settings/api-reference/get-account-verify_credentials
             :allowed_param: 'include_entities', 'skip_status', 'include_email'
         """
+
+        if self.auth.consumer_key is None:
+            return False
+        
         if 'include_email' in kwargs:
             kwargs['include_email'] = str(kwargs['include_email']).lower()
         try:


### PR DESCRIPTION
Fixes tweepy/tweepy#1489