### PR TITLE
Remove async from filter and sample functions

### DIFF
--- a/tweepy/asynchronous/streaming.py
+++ b/tweepy/asynchronous/streaming.py
@@ -146,9 +146,7 @@ class AsyncStream:
 
     def filter(self, *, follow=None, track=None, locations=None,
                      filter_level=None, languages=None, stall_warnings=False):
-        """|coroutine|
-
-        Filter realtime Tweets
+        """Filter realtime Tweets
 
         Parameters
         ----------
@@ -235,9 +233,7 @@ class AsyncStream:
         return self.task
 
     def sample(self, *, languages=None, stall_warnings=False):
-        """|coroutine|
-
-        Sample realtime Tweets
+        """Sample realtime Tweets
 
         Parameters
         ----------

--- a/tweepy/asynchronous/streaming.py
+++ b/tweepy/asynchronous/streaming.py
@@ -144,7 +144,7 @@ class AsyncStream:
             await self.session.close()
             await self.on_disconnect()
 
-    async def filter(self, *, follow=None, track=None, locations=None,
+    def filter(self, *, follow=None, track=None, locations=None,
                      filter_level=None, languages=None, stall_warnings=False):
         """|coroutine|
 
@@ -234,7 +234,7 @@ class AsyncStream:
         )
         return self.task
 
-    async def sample(self, *, languages=None, stall_warnings=False):
+    def sample(self, *, languages=None, stall_warnings=False):
         """|coroutine|
 
         Sample realtime Tweets


### PR DESCRIPTION
I think `filter` and `sample` functions shouldn't be `async` since they only return a task.

This way, we can directly execute the task:
```
await AsyncStream.filter()
```

If the `async` is left, it forces us to use an initial `await` to retrieve the task and then another `await` to execute it:
```
task = await AsyncStream.filter()
await task
```

