### PR TITLE
Update documentation for API.rate_limit_status to be consistent with other docstrings

### DIFF
--- a/tweepy/api.py
+++ b/tweepy/api.py
@@ -3942,8 +3942,11 @@ class API:
         resource families. When using application-only auth, this method's
         response indicates the application-only auth rate limiting context.
 
-        :param resources: A comma-separated list of resource families you want
-                          to know the current rate limit disposition for.
+        Parameters
+        ----------
+        resources
+            A comma-separated list of resource families you want to know the 
+            current rate limit disposition for.
 
         Returns
         -------


### PR DESCRIPTION
After running into #1596, I ended up cloning the project and doing a little digging and saw the recent commit history updating the docs.

I found one method that seemed to not be updated (i just did a project search for `:param`). I just updated it to be consistent with the rest of the method docstrings.

Open to any feedback in case I missed anything