### PR TITLE
fix asyncio timeout error when getting rate limit, status code 420

### DIFF
--- a/tweepy/asynchronous/streaming.py
+++ b/tweepy/asynchronous/streaming.py
@@ -3,6 +3,7 @@
 # See LICENSE for details.
 
 import asyncio
+from asyncio import TimeoutError
 import json
 import logging
 from math import inf
@@ -128,7 +129,8 @@ class AsyncStream:
                                 if http_error_wait > http_error_wait_max:
                                     http_error_wait = http_error_wait_max
                 except (aiohttp.ClientConnectionError,
-                        aiohttp.ClientPayloadError) as e:
+                        aiohttp.ClientPayloadError,
+                        asyncio.TimeoutError) as e:
                     await self.on_connection_error()
 
                     await asyncio.sleep(network_error_wait)


### PR DESCRIPTION
improves handle connection errors when asynchronous streaming.

asyncio runs into timeout error if stream reaches rate limit (status_code 420). This is similar to https://github.com/tweepy/tweepy/commit/68e19cc6b9b23d72369ca1520093770eb18a5a9f
