### PR TITLE
Raise NotFound on v2 404 requests

### DIFF
--- a/tweepy/client.py
+++ b/tweepy/client.py
@@ -13,8 +13,8 @@ import requests
 import tweepy
 from tweepy.auth import OAuthHandler
 from tweepy.errors import (
-    BadRequest, Forbidden, HTTPException, TooManyRequests, TwitterServerError,
-    Unauthorized
+    BadRequest, Forbidden, HTTPException, NotFound, TooManyRequests,
+    TwitterServerError, Unauthorized
 )
 from tweepy.media import Media
 from tweepy.place import Place
@@ -103,7 +103,8 @@ class Client:
                 raise Unauthorized(response)
             if response.status_code == 403:
                 raise Forbidden(response)
-            # Handle 404?
+            if response.status_code == 404:
+                raise NotFound(response)
             if response.status_code == 429:
                 if self.wait_on_rate_limit:
                     reset_time = int(response.headers["x-rate-limit-reset"])


### PR DESCRIPTION
Raise a `NotFound` exception on requests with a status code of `404` when using `Client`, for consistency with `API` behavior and developer expectations.