### PR TITLE
tweak streaming docs to show correct parameter

### DIFF
--- a/tweepy/asynchronous/streaming.py
+++ b/tweepy/asynchronous/streaming.py
@@ -176,7 +176,7 @@ class AsyncStream:
             language identifiers corresponding to any of the languages listed
             on Twitter’s `advanced search`_ page will only return Tweets that
             have been detected as being written in the specified languages. For
-            example, connecting with language=en will only stream Tweets
+            example, connecting with languages=['en'] will only stream Tweets
             detected to be in the English language.
         stall_warnings: Optional[bool]
             Specifies whether stall warnings should be delivered. See
@@ -243,7 +243,7 @@ class AsyncStream:
             language identifiers corresponding to any of the languages listed
             on Twitter’s `advanced search`_ page will only return Tweets that
             have been detected as being written in the specified languages. For
-            example, connecting with language=en will only stream Tweets
+            example, connecting with languages=['en'] will only stream Tweets
             detected to be in the English language.
         stall_warnings: Optional[bool]
             Specifies whether stall warnings should be delivered. See

--- a/tweepy/streaming.py
+++ b/tweepy/streaming.py
@@ -214,7 +214,7 @@ class Stream:
             language identifiers corresponding to any of the languages listed
             on Twitter’s `advanced search`_ page will only return Tweets that
             have been detected as being written in the specified languages. For
-            example, connecting with language=en will only stream Tweets
+            example, connecting with languages=['en'] will only stream Tweets
             detected to be in the English language.
         stall_warnings : bool
             Specifies whether stall warnings should be delivered
@@ -279,7 +279,7 @@ class Stream:
             language identifiers corresponding to any of the languages listed
             on Twitter’s `advanced search`_ page will only return Tweets that
             have been detected as being written in the specified languages. For
-            example, connecting with language=en will only stream Tweets
+            example, connecting with languages=['en'] will only stream Tweets
             detected to be in the English language.
         stall_warnings : bool
             Specifies whether stall warnings should be delivered


### PR DESCRIPTION
The actual parameter the programmer passes to the function is "languages", and takes a list; "language=en" is what's happening behind the scenes but that's not how you would code this.