### PR TITLE
Documentation: Added screen_name parameter to get_user method

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -50,7 +50,7 @@ from Twitter which we can then use inside our application. For example
 the following code returns to us a User model::
 
    # Get the User object for twitter...
-   user = api.get_user('twitter')
+   user = api.get_user(screen_name='twitter')
 
 Models contain the data and some helper methods which we can then
 use::


### PR DESCRIPTION
In the Getting started section of the documentation, under Models sub-heading, its mentioned as:

    user = api.get_user('twitter')

but it returns the error found below: 

> TypeError: get_user() takes 1 positional argument but 2

were given.

So it would be easier for dummies like me, if its mentioned as 

    user = api.get_user(screen_name='twitter')

instead, as it improves clarity.