### PR TITLE
Minor fix(es) to Client's _make_request

### DIFF
--- a/tweepy/client.py
+++ b/tweepy/client.py
@@ -156,7 +156,8 @@ class Client:
                 if param_value.tzinfo is not None:
                     param_value = param_value.astimezone(datetime.timezone.utc)
                 request_params[param_name] = param_value.strftime(
-                    "%Y-%m-%dT%H:%M:%S.%fZ")
+                    "%Y-%m-%dT%H:%M:%S.%fZ"
+                )
                 # TODO: Constant datetime format string?
             else:
                 request_params[param_name] = param_value

--- a/tweepy/client.py
+++ b/tweepy/client.py
@@ -155,7 +155,8 @@ class Client:
             elif isinstance(param_value, datetime.datetime):
                 if param_value.tzinfo is not None:
                     param_value = param_value.astimezone(datetime.timezone.utc)
-                request_params[param_name] = param_value.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+                request_params[param_name] = param_value.strftime(
+                    "%Y-%m-%dT%H:%M:%S.%fZ")
                 # TODO: Constant datetime format string?
             else:
                 request_params[param_name] = param_value
@@ -186,7 +187,7 @@ class Client:
             includes["media"] = [Media(media) for media in includes["media"]]
         if "places" in includes:
             includes["places"] = [Place(place) for place in includes["places"]]
-        if "poll" in includes:
+        if "polls" in includes:
             includes["polls"] = [Poll(poll) for poll in includes["polls"]]
         if "tweets" in includes:
             includes["tweets"] = [Tweet(tweet) for tweet in includes["tweets"]]
@@ -2499,7 +2500,7 @@ class Client:
             "GET", route, params=params,
             endpoint_parameters=(
                 "expansions", "list.fields", "user.fields"
-            ), data_type=List, user_auth = True
+            ), data_type=List, user_auth=True
         )
 
     def pin_list(self, list_id):


### PR DESCRIPTION
The current code in master has 

```
if "poll" in includes:
            includes["polls"] = [Poll(poll) for poll in includes["polls"]]
```

on lines 189-190 in `client.py`. Because the key in the `includes` dictionary is actually `polls` instead of `poll`, line 190 is never executed, and thus the poll dictionaries fetched using the Twitter get request are never converted to Poll objects. This affects code consistency because all of the dictionaries in `includes["tweets"]`,  `includes["users"]`, `includes["media"]`, and `includes["places"]` get transformed into Tweet, User, Media, and Place objects respectively.

The other 2 fixes are trivial style fixes only (added line break so the line isn't too long, and removed spaces surrounding = for styling consistency).