### PR TITLE
fix pagination for tweet counts

### DIFF
--- a/tweepy/pagination.py
+++ b/tweepy/pagination.py
@@ -88,7 +88,8 @@ class PaginationIterator:
 
         # https://twittercommunity.com/t/why-does-timeline-use-pagination-token-while-search-uses-next-token/150963
         if self.method.__name__ in ("search_all_tweets",
-                                    "search_recent_tweets"):
+                                    "search_recent_tweets",
+                                    "get_all_tweets_count"):
             self.kwargs["next_token"] = pagination_token
         else:
             self.kwargs["pagination_token"] = pagination_token


### PR DESCRIPTION
`get_all_tweets_count` is using `next_token` for pagination.
`next_token` is returned only when a difference between start and end time is more than 31 days, no matter the granularity.