### PR TITLE
Fixed date formatting for datetime objects

### DIFF
--- a/tweepy/client.py
+++ b/tweepy/client.py
@@ -156,7 +156,7 @@ class Client:
                 if param_value.tzinfo is not None:
                     param_value = param_value.astimezone(datetime.timezone.utc)
                 request_params[param_name] = param_value.strftime(
-                    "%Y-%m-%dT%H:%M:%S.%fZ"
+                    "%Y-%m-%dT%H:%M:%SZ"
                 )
                 # TODO: Constant datetime format string?
             else:


### PR DESCRIPTION
https://docs.tweepy.org/en/stable/client.html

Required Format:
YYYY-MM-DDTHH:mm:ssZ (ISO 8601/RFC 3339)

Docs are already up to date. 
"Please note that this parameter does not support a millisecond value."