### PR TITLE
Fix 3 typos in auth documentation

### DIFF
--- a/docs/authentication.rst
+++ b/docs/authentication.rst
@@ -199,7 +199,7 @@ they'll be redirected to the Callback / Redirect URI / URL you provided, with
 
 You can then use the verifier to get the access token and secret::
 
-    access_token, access_token_secret = oauth1_user_handler.fetch_token(
+    access_token, access_token_secret = oauth1_user_handler.get_access_token(
         "Verifier (oauth_verifier) here"
     )
 
@@ -218,7 +218,7 @@ and secret::
         "oauth_token": "Request Token (oauth_token) here",
         "oauth_token_secret": request_secret
     }
-    access_token, access_token_secret = new_oauth1_user_handler.fetch_token(
+    access_token, access_token_secret = new_oauth1_user_handler.get_access_token(
         "Verifier (oauth_verifier) here"
     )
 
@@ -272,7 +272,7 @@ When the user authenticates with this URL, they'll be provided a PIN. You can
 retrieve this PIN from the user to use as the verifier::
 
     verifier = input("Input PIN: ")
-    access_token, access_token_secret = oauth1_user_handler.fetch_token(
+    access_token, access_token_secret = oauth1_user_handler.get_access_token(
         verifier
     )
 


### PR DESCRIPTION
The method on `OAuth1UserHandler` is actually called `get_access_token`, not `fetch_token` (like it is in the `Oauth2UserHandler`).

Updating the docs so others hitting this don't have to dig through the source code to figure out why the example code isn't working.