### PR TITLE
Fix `AttributeError` by accessing `meta` field when `return_type` is dict

### DIFF
--- a/tweepy/asynchronous/pagination.py
+++ b/tweepy/asynchronous/pagination.py
@@ -16,8 +16,8 @@ class AsyncPaginator:
     .. note::
 
         When the returned response from the method being passed is of type
-        :class:`aiohttp.ClientResponse`, it will be deserialized in order to parse
-        the pagination tokens, likely negating any potential performance
+        :class:`aiohttp.ClientResponse`, it will be deserialized in order to
+        parse the pagination tokens, likely negating any potential performance
         benefits from using a :class:`aiohttp.ClientResponse` return type.
 
     .. versionadded:: 4.11

--- a/tweepy/asynchronous/pagination.py
+++ b/tweepy/asynchronous/pagination.py
@@ -13,14 +13,14 @@ class AsyncPaginator:
     """:class:`AsyncPaginator` can be used to paginate for any
     :class:`AsyncClient` methods that support pagination
 
-    .. versionadded:: 4.11
-
     .. note::
 
         When the returned response from the method being passed is of type
         :class:`aiohttp.ClientResponse`, it will be deserialized in order to parse
         the pagination tokens, likely negating any potential performance
         benefits from using a :class:`aiohttp.ClientResponse` return type.
+
+    .. versionadded:: 4.11
 
     Parameters
     ----------

--- a/tweepy/pagination.py
+++ b/tweepy/pagination.py
@@ -13,14 +13,14 @@ class Paginator:
     """:class:`Paginator` can be used to paginate for any :class:`Client`
     methods that support pagination
 
-    .. versionadded:: 4.0
-
     .. note::
 
         When the returned response from the method being passed is of type
         :class:`requests.Response`, it will be deserialized in order to parse
         the pagination tokens, likely negating any potential performance
         benefits from using a :class:`requests.Response` return type.
+
+    .. versionadded:: 4.0
 
     Parameters
     ----------

--- a/tweepy/pagination.py
+++ b/tweepy/pagination.py
@@ -17,9 +17,10 @@ class Paginator:
 
     .. note::
 
-        When passing ``return_type=requests.Response`` to :class:`Client` for
-        pagination, payload of response will be deserialized implicitly to get
-        ``meta`` attribute every requests, which may affect performance.
+        When the returned response from the method being passed is of type
+        :class:`requests.Response`, it will be deserialized in order to parse
+        the pagination tokens, likely negating any potential performance
+        benefits from using a :class:`requests.Response` return type.
 
     Parameters
     ----------
@@ -40,7 +41,8 @@ class Paginator:
         return PaginationIterator(self.method, *self.args, **self.kwargs)
 
     def __reversed__(self):
-        return PaginationIterator(self.method, *self.args, reverse=True, **self.kwargs)
+        return PaginationIterator(self.method, *self.args, reverse=True,
+                                  **self.kwargs)
 
     def flatten(self, limit=inf):
         """Flatten paginated data
@@ -54,7 +56,8 @@ class Paginator:
             return
 
         count = 0
-        for response in PaginationIterator(self.method, *self.args, **self.kwargs):
+        for response in PaginationIterator(self.method, *self.args,
+                                           **self.kwargs):
             if response.data is not None:
                 for data in response.data:
                     yield data
@@ -64,9 +67,9 @@ class Paginator:
 
 
 class PaginationIterator:
-    def __init__(
-        self, method, *args, limit=inf, pagination_token=None, reverse=False, **kwargs
-    ):
+
+    def __init__(self, method, *args, limit=inf, pagination_token=None,
+                 reverse=False, **kwargs):
         self.method = method
         self.args = args
         self.limit = limit
@@ -96,9 +99,8 @@ class PaginationIterator:
 
         # https://twittercommunity.com/t/why-does-timeline-use-pagination-token-while-search-uses-next-token/150963
         if self.method.__name__ in (
-            "search_all_tweets",
-            "search_recent_tweets",
-            "get_all_tweets_count",
+            "search_all_tweets", "search_recent_tweets",
+            "get_all_tweets_count"
         ):
             self.kwargs["next_token"] = pagination_token
         else:


### PR DESCRIPTION
I meet totally the same error to #1843 

```
Traceback (most recent call last):
  File "${MY_PY_ENV}/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "${MY_PY_ENV}/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "${MY_WORKSPACE}/twitter_fetcher/fetch_tweet_timeline.py", line 174, in <module>
    main()
  File "${MY_WORKSPACE}/twitter_fetcher/fetch_tweet_timeline.py", line 84, in main
    for i, resp in enumerate(
  File "${MY_PY_ENV}/lib/python3.10/site-packages/tweepy/pagination.py", line 100, in __next__
    self.previous_token = response.meta.get("previous_token")
AttributeError: 'dict' object has no attribute 'meta'
```

My solution is to add an `isinstance` condition, it's very simple but useful. Any improvement or suggest for this PR is welcome.

Regards.