### PR TITLE
Optimize request intervals for full archive search with OAuth 2.0 Bearer Token for pagination.py

### DIFF
--- a/tweepy/pagination.py
+++ b/tweepy/pagination.py
@@ -1,7 +1,7 @@
 # Tweepy
 # Copyright 2009-2022 Joshua Roesslein
 # See LICENSE for details.
-
+import time
 from math import inf
 
 
@@ -78,6 +78,8 @@ class PaginationIterator:
         return self
 
     def __next__(self):
+        t0: float = time.time()
+
         if self.reverse:
             pagination_token = self.previous_token
         else:
@@ -88,8 +90,9 @@ class PaginationIterator:
 
         # https://twittercommunity.com/t/why-does-timeline-use-pagination-token-while-search-uses-next-token/150963
         if self.method.__name__ in (
-            "search_all_tweets", "search_recent_tweets",
-            "get_all_tweets_count"
+                "search_all_tweets",
+                "search_recent_tweets",
+                "get_all_tweets_count"
         ):
             self.kwargs["next_token"] = pagination_token
         else:
@@ -100,5 +103,11 @@ class PaginationIterator:
         self.previous_token = response.meta.get("previous_token")
         self.next_token = response.meta.get("next_token")
         self.count += 1
+
+        if self.method.__name__ == "search_all_tweets" and self.method.__self__.bearer_token:
+            # It is required by Twitter that one request per second is made during an archive search
+            # with OAuth 2.0 Bearer Token. cf. https://developer.twitter.com/en/docs/twitter-api/tweets/search/migrate.
+            # The minimum is 1 request per second, the maximum for optimal throughput is 300 requests per 900 seconds.
+            time.sleep(1 - ((time.time() - t0) % 1))
 
         return response


### PR DESCRIPTION
With this PR I would like to solve the issues raised in #1688 #1907 and #1871 of missing wait time between requests for Twitter api v2, which causes a direct exceeding of rate limits during a full archive search.

The problem seems not to be in [https://github.com/tweepy/tweepy/blob/master/tweepy/client.py](url) as in #1871, but rather in [https://github.com/tweepy/tweepy/blob/master/tweepy/pagination.py](url) as described in #1688.

It is a way to simply wait one second at the end of each request and the processing time of the data, but this always requires consideration and knowledge of the problem by the user.
Likewise, it may happen that the optimal time windows of 1 request per second and 300 requests per 900 requests (3 seconds for request + processing) cannot be met if 1 second is always added to the request and processing time.

Mainly, though, I think the problem should be solved within Tweepy, since the user (at least I did and take some time to find the problem) assumes that Tweepy implements Twitter's guidelines.

Since the Twitter guidelines only require a limit of 1 request per second for the full archive search `/2/tweets/search/all` in combination with OAuth 2.0 Bearer Token cf. https://developer.twitter.com/en/docs/twitter-api/tweets/search/migrate it seems appropriate to measure the time from the beginning in `__next__` of [https://github.com/tweepy/tweepy/blob/master/tweepy/pagination.py](url) and to fill up the next second after receiving the response.

Cheers :-)