### PR TITLE
Added https:// prefix to host and upload_host init args for API class

### DIFF
--- a/tweepy/api.py
+++ b/tweepy/api.py
@@ -90,9 +90,9 @@ class API:
     """
 
     def __init__(
-        self, auth=None, *, cache=None, host='api.twitter.com', parser=None,
+        self, auth=None, *, cache=None, host='https://api.twitter.com', parser=None,
         proxy=None, retry_count=0, retry_delay=0, retry_errors=None,
-        timeout=60, upload_host='upload.twitter.com', user_agent=None,
+        timeout=60, upload_host='https://upload.twitter.com', user_agent=None,
         wait_on_rate_limit=False
     ):
         self.auth = auth
@@ -154,9 +154,9 @@ class API:
         # Build the request URL
         path = f'/1.1/{endpoint}.json'
         if upload_api:
-            url = 'https://' + self.upload_host + path
+            url = self.upload_host + path
         else:
-            url = 'https://' + self.host + path
+            url = self.host + path
 
         if params is None:
             params = {}


### PR DESCRIPTION
For the `API.__init__` arguments, I believe it's better if `host` and `upload_host` are passed with the `https://` prefix already. That way one can also mock twitter api by passing other protocol such as `http`.  This makes it easier for development, without the need to create some local certificates.