### PR TITLE
pagination.py fixed

### DIFF
--- a/tweepy/pagination.py
+++ b/tweepy/pagination.py
@@ -97,8 +97,14 @@ class PaginationIterator:
 
         response = self.method(*self.args, **self.kwargs)
 
-        self.previous_token = response.meta.get("previous_token")
-        self.next_token = response.meta.get("next_token")
+        if isinstance(response, Response):
+            response = response.json()
+            self.previous_token = response['meta'].get("previous_token")
+            self.next_token = response['meta'].get("next_token")
+        else:
+            self.previous_token = response.meta.get("previous_token")
+            self.next_token = response.meta.get("next_token")
+
         self.count += 1
 
         return response


### PR DESCRIPTION
The error "AttributeError: 'Response' object has no attribute 'meta'" was corrected. This happens when I initialize the Client object with the "return_type=requests.Response" parameter.