### PR TITLE
Breakout Response creation into separate method

### DIFF
--- a/tweepy/client.py
+++ b/tweepy/client.py
@@ -137,6 +137,9 @@ class BaseClient:
         if self.return_type is dict:
             return response
 
+        return self._construct_response(response, data_type=data_type)
+
+    def _construct_response(self, response, data_type=None):
         data = response.get("data")
         data = self._process_data(data, data_type=data_type)
 


### PR DESCRIPTION
As a workaround to folks who would like the headers from a `requests.Response` but also the nice, neat `tweepy.Response` data type? I think #1984 and #1989 might be related?