### PR TITLE
Add types to `auth.py`

### DIFF
--- a/tweepy/typing.py
+++ b/tweepy/typing.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING, TypeVar
+
+if TYPE_CHECKING:
+    if sys.version_info >= (3, 10):
+        from typing import TypeAlias
+    else:
+        from typing_extensions import TypeAlias
+    # Remove when support for Python 3.9 is dropped
+
+    T = TypeVar("T")
+
+    LTSType: TypeAlias = list[T] | tuple[T] | set[T]


### PR DESCRIPTION
Noticed there's no code formatting applied to this library. We might want to use `isort` and a code formatter (e.g `black`), as type hints addition will require a lot of imports.