### PR TITLE
Fix KeyError in chunked upload method

### DIFF
--- a/tweepy/api.py
+++ b/tweepy/api.py
@@ -3685,7 +3685,7 @@ class API:
 
         if wait_for_async_finalize and hasattr(media, 'processing_info'):
             while media.processing_info['state'] in ('pending', 'in_progress'):
-                time.sleep(media.processing_info['check_after_secs'])
+                time.sleep(media.processing_info.get('check_after_secs', 5))
                 media = self.get_media_upload_status(media.media_id, **kwargs)
 
         return media


### PR DESCRIPTION
The Twitter API has stopped reliably returning the 'check_after_secs' key-value pair in their response to the chunked media upload endpoint.

This PR fixes the issue.

Until this is merged, we plan to start using my own forked branch.

![CleanShot 2023-01-27 at 10 35 49@2x](https://user-images.githubusercontent.com/715405/215066305-1a07b581-4010-440e-bc8e-947b85fb6109.png)
