### PR TITLE
Tweet: test pickle, unpickle, fix recursion

### DIFF
--- a/tests/test_tweets.py
+++ b/tests/test_tweets.py
@@ -1,0 +1,20 @@
+import pickle
+import unittest
+
+from tweepy.tweet import Tweet
+
+
+class TweepyTweetTests(unittest.TestCase):
+    def test_tweet(self):
+        t = Tweet(
+            data={
+                "edit_history_tweet_ids": ["16213149247090909"],
+                "id": "16213149247090909",
+                "text": "We're super excited to not only welcome the Flamingo Janes in...",
+            }
+        )
+
+        pickled_tweet = pickle.dumps(t)
+        t2 = pickle.loads(pickled_tweet)
+
+        self.assertDictEqual(t.data, t2.data)

--- a/tweepy/mixins.py
+++ b/tweepy/mixins.py
@@ -26,17 +26,21 @@ class DataMapping(Mapping):
     __slots__ = ()
 
     def __contains__(self, item):
-        return item in self.data
+        data = DataMapping.__getattribute__(self, "data")
+        return item in data
 
     def __getattr__(self, name):
+        data = DataMapping.__getattribute__(self, "data")
+        if name == "data":
+            return data
         try:
-            return self.data[name]
+            return data[name]
         except KeyError:
             raise AttributeError from None
 
     def __getitem__(self, key):
         try:
-            return getattr(self, key)
+            return DataMapping.__getattribute__(self, key)
         except AttributeError:
             raise KeyError from None
     


### PR DESCRIPTION
Ok, I have been bitten by this before, so I knew there was something in the python docs... somewhere...

https://docs.python.org/3/reference/datamodel.html?highlight=__getattr__#object.__getattribute__

> In order to avoid infinite recursion in this method, its implementation should always call the base class method with the same name to access any attributes it needs, for example, object.__getattribute__(self, name).

Here is a test and an implementation of the suggestion above... as the mixin class elevates `data` as the origin of all state and maps itself again into it...