### PR TITLE
Using `backoff.on_exception` decorator to solve #1606

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,128 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+[Official Discord Server](https://discord.gg/bJvqnhg).
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.


### PR DESCRIPTION
This PR consist as follows:
- [x] Added CoC (might suggest another yellow dotted bullet list below if the members don't mind)
- [x] Using `backoff.on_exception` decorator to #1606 (worked on my case, would like to take a look)

1. Yellow dotted bullet list, I just completed one at a time to see if you guys open with this kind of PR
![yellow dotted ](https://user-images.githubusercontent.com/36787606/221126488-b5c65d55-03af-468d-85ce-3faf5a9b927d.png)

2. I came across this problem on Discord while trying to handle [another issue](https://discord.com/channels/432685901596852224/1078206406349557850). I noticed when I worked with my code to scrap certain tweets my connection always aborted since it took me so long to code and always rerun certain cells on my JupyterNB. So I chat with my ChatGPT, Gept, to solve this all together. I stumbled upon this #1606 while searching for the answer as well.

3. Gept was leading me to use the `backoff` module since I thought the connection need to be tried until the rate limit reset later.

> Initial brainstorming
![initial brainstorming](https://user-images.githubusercontent.com/36787606/221128860-0f25eb16-9a01-42cb-8216-3e03904f51ec.png)
> Initial suspect of the main problem while looking at the `Tweepy` source code
![main problem](https://user-images.githubusercontent.com/36787606/221129026-8f2d3ea0-93f0-4a56-b120-267671ce6406.png)
> Interested to other modules as solution
![other modules](https://user-images.githubusercontent.com/36787606/221129149-6daedbcc-c78e-4167-8018-bdbb8e176b42.png)

4. I tested it successfully with this snippet line of code. I was using `Client.get_liked_tweets` method and custom `Paginator` subclass to achieve this result below.
```python
import tweepy as tw
from backoff import on_exception, random_jitter, expo
from urllib3.exceptions import ProtocolError
from requests.exceptions import ConnectionError, ChunkedEncodingError
from tweepy.errors import TweepyException

class NewClient(tw.Client):
    @on_exception(expo, (ProtocolError, ConnectionError, ChunkedEncodingError, TweepyException), jitter=random_jitter, factor=2)
    def request(self, method, route, params=None, json=None, user_auth=False):
        return super().request(method, route, params, json, user_auth)
```

> Before
![before](https://user-images.githubusercontent.com/36787606/221131029-01febc82-086a-4bff-a4ae-790e75d91255.png)

> After
![after](https://user-images.githubusercontent.com/36787606/221131676-838e4f66-02dd-4c9f-9a44-887fd6ad5202.png)

5. The reason for the tuple of exception class in that parameter. I edited the `` to adjust for now.
![import](https://user-images.githubusercontent.com/36787606/221133098-9c4c0168-9ac4-4641-9e05-c2df7fdbe5ee.png)

> I'm not so sure with `from requests.packages.urllib3.exceptions import ProtocolError` they indirectly suggested in #1606 since it has the same exception class as `from urllib3.exceptions import ProtocolError` although Gept said it was different. Therefore it might not cover the problem ideally. I might suggest using the base exception class of all modules.
![diff](https://user-images.githubusercontent.com/36787606/221133898-3153fe7e-00a4-40c5-b597-c4da24e2bfaf.png)
