### PR TITLE
# Add progress bar to track the sleep time after "Rate limit reached" warning

### DIFF
--- a/tweepy/client.py
+++ b/tweepy/client.py
@@ -4,6 +4,8 @@
 
 from collections import namedtuple
 import datetime
+import time
+from tqdm import tqdm
 
 try:
     from functools import cache
@@ -107,8 +109,14 @@ class BaseClient:
                     if sleep_time > 0:
                         log.warning(
                             "Rate limit exceeded. "
-                            f"Sleeping for {sleep_time} seconds."
+                            "Sleeping for {} seconds.".format(sleep_time)
                         )
+                        # Add progress bar
+                        with tqdm(total=sleep_time) as pbar:
+                            for _ in range(sleep_time):
+                                time.sleep(1)
+                                pbar.update(1)
+
                         time.sleep(sleep_time)
                     return self.request(method, route, params, json, user_auth)
                 else:


### PR DESCRIPTION
This change resolves issue #2096 by adding a progress bar to track the sleep time after reaching the rate limit of Twitter API.