### PR TITLE
deps: bump requests-oauthlib to <3 to allow v2.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     install_requires=[
         "oauthlib>=3.2.0,<4",
         "requests>=2.27.0,<3",
-        "requests-oauthlib>=1.2.0,<2",
+        "requests-oauthlib>=1.2.0,<3",
     ],
     extras_require={
         "async": [


### PR DESCRIPTION
Hi! First, thanks for maintaining tweepy. It's great!

Tests are passing for me with requests-oauthlib v2.0.0. Here's the changelog: https://github.com/requests/requests-oauthlib/blob/master/HISTORY.rst#v200-22-march-2024 . The main reason for the major version bump seems to be removing support for Python 2.3 and <3.7, and tweepy already requires 3.7, so that shouldn't be a problem.