### PR TITLE
 avoid truncated tweet texts

### DIFF
--- a/tweepy/tweet.py
+++ b/tweepy/tweet.py
@@ -29,6 +29,7 @@ PUBLIC_TWEET_FIELDS = [
     "source",
     "text",
     "withheld",
+    "note_tweet"
 ]
 
 #: All the potential fields for :class:`Tweet` objects


### PR DESCRIPTION
Add note_tweet to avoid truncated tweet texts

Ref: https://developer.twitter.com/en/docs/twitter-api/tweets/lookup/api-reference/get-tweets
