### PR TITLE
GitHub Actions: Test on Python 3.13 beta

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,14 +7,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import sys
 import time
 import unittest
 from ast import literal_eval
@@ -100,14 +101,17 @@ class TweepyAPITests(TweepyTestCase):
         update = self.api.update_status_with_media(tweet_text, 'assets/banner.png')
         self.assertIn(tweet_text + ' https://t.co', update.text)
 
+    @unittest.skipIf(sys.version_info >= (3, 13), "imghdr was removed in Python 3.13")
     @tape.use_cassette('testmediauploadpng.yaml')
     def testmediauploadpng(self):
         self.api.media_upload('assets/banner.png')
 
+    @unittest.skipIf(sys.version_info >= (3, 13), "imghdr was removed in Python 3.13")
     @tape.use_cassette('testmediauploadgif.yaml')
     def testmediauploadgif(self):
         self.api.media_upload('assets/animated.gif')
 
+    @unittest.skipIf(sys.version_info >= (3, 13), "imghdr was removed in Python 3.13")
     @tape.use_cassette('testmediauploadmp4.yaml')
     def testmediauploadmp4(self):
         self.api.media_upload('assets/video.mp4')

--- a/tweepy/api.py
+++ b/tweepy/api.py
@@ -4,7 +4,6 @@
 
 import contextlib
 import functools
-import imghdr
 import logging
 import mimetypes
 from platform import python_version
@@ -3468,6 +3467,10 @@ class API:
         ----------
         https://developer.twitter.com/en/docs/twitter-api/v1/media/upload-media/overview
         """
+        try:
+            import imghdr
+        except ModuleNotFoundError:
+            raise NotImplementedError("media_upload() is not implemented on Python >= 3.13")
         h = None
         if file is not None:
             location = file.tell()


### PR DESCRIPTION
Confirms:
* #2177

Related:
* #1086 -- ~@shuuji3 Would you be able to propose a new fix?~

https://www.python.org/downloads/release/python-3130b1/

Raises `ModuleNotFoundError: No module named 'imghdr'` because Python 3.13 removes it from the Standard Library.
* https://docs.python.org/3/library/imghdr.html

---

> imghdr: use the projects [filetype](https://pypi.org/project/filetype/), [puremagic](https://pypi.org/project/puremagic/), or [python-magic](https://pypi.org/project/python-magic/) instead. (Contributed by Victor Stinner in [gh-104773](https://github.com/python/cpython/issues/104773).)

https://docs.python.org/3.13/whatsnew/3.13.html#pep-594-dead-batteries-and-other-module-removals