### PR TITLE
Fix f-string without any placeholders

### DIFF
--- a/tweepy/asynchronous/client.py
+++ b/tweepy/asynchronous/client.py
@@ -754,7 +754,7 @@ class AsyncClient(AsyncBaseClient):
             json["text"] = text
 
         return await self._make_request(
-            "POST", f"/2/tweets", json=json, user_auth=user_auth
+            "POST", "/2/tweets", json=json, user_auth=user_auth
         )
 
     # Quote Tweets
@@ -2268,7 +2268,7 @@ class AsyncClient(AsyncBaseClient):
         https://developer.twitter.com/en/docs/twitter-api/users/lookup/api-reference/get-users-me
         """
         return await self._make_request(
-            "GET", f"/2/users/me", params=params,
+            "GET", "/2/users/me", params=params,
             endpoint_parameters=("expansions", "tweet.fields", "user.fields"),
             data_type=User, user_auth=user_auth
         )
@@ -3294,7 +3294,7 @@ class AsyncClient(AsyncBaseClient):
             json["private"] = private
 
         return await self._make_request(
-            "POST", f"/2/lists", json=json, user_auth=user_auth
+            "POST", "/2/lists", json=json, user_auth=user_auth
         )
 
     # Pinned Lists

--- a/tweepy/asynchronous/streaming.py
+++ b/tweepy/asynchronous/streaming.py
@@ -306,7 +306,7 @@ class AsyncStreamingClient(AsyncBaseClient, AsyncBaseStream):
                 json["add"].append({"value": rule.value})
 
         return await self._make_request(
-            "POST", f"/2/tweets/search/stream/rules", params=params,
+            "POST", "/2/tweets/search/stream/rules", params=params,
             endpoint_parameters=("dry_run",), json=json, data_type=StreamRule
         )
 
@@ -345,7 +345,7 @@ class AsyncStreamingClient(AsyncBaseClient, AsyncBaseStream):
                 json["delete"]["ids"].append(str(id))
 
         return await self._make_request(
-            "POST", f"/2/tweets/search/stream/rules", params=params,
+            "POST", "/2/tweets/search/stream/rules", params=params,
             endpoint_parameters=("dry_run",), json=json, data_type=StreamRule
         )
 
@@ -455,7 +455,7 @@ class AsyncStreamingClient(AsyncBaseClient, AsyncBaseStream):
         https://developer.twitter.com/en/docs/twitter-api/tweets/filtered-stream/api-reference/get-tweets-search-stream-rules
         """
         return await self._make_request(
-            "GET", f"/2/tweets/search/stream/rules", params=params,
+            "GET", "/2/tweets/search/stream/rules", params=params,
             endpoint_parameters=("ids",), data_type=StreamRule
         )
 

--- a/tweepy/client.py
+++ b/tweepy/client.py
@@ -837,7 +837,7 @@ class Client(BaseClient):
             json["text"] = text
 
         return self._make_request(
-            "POST", f"/2/tweets", json=json, user_auth=user_auth
+            "POST", "/2/tweets", json=json, user_auth=user_auth
         )
 
     # Quote Tweets
@@ -2451,7 +2451,7 @@ class Client(BaseClient):
         https://developer.twitter.com/en/docs/twitter-api/users/lookup/api-reference/get-users-me
         """
         return self._make_request(
-            "GET", f"/2/users/me", params=params,
+            "GET", "/2/users/me", params=params,
             endpoint_parameters=("expansions", "tweet.fields", "user.fields"),
             data_type=User, user_auth=user_auth
         )
@@ -3547,7 +3547,7 @@ class Client(BaseClient):
             json["private"] = private
 
         return self._make_request(
-            "POST", f"/2/lists", json=json, user_auth=user_auth
+            "POST", "/2/lists", json=json, user_auth=user_auth
         )
 
     # Pinned Lists

--- a/tweepy/streaming.py
+++ b/tweepy/streaming.py
@@ -331,7 +331,7 @@ class StreamingClient(BaseClient, BaseStream):
                 json["add"].append({"value": rule.value})
 
         return self._make_request(
-            "POST", f"/2/tweets/search/stream/rules", params=params,
+            "POST", "/2/tweets/search/stream/rules", params=params,
             endpoint_parameters=("dry_run",), json=json, data_type=StreamRule
         )
 
@@ -368,7 +368,7 @@ class StreamingClient(BaseClient, BaseStream):
                 json["delete"]["ids"].append(str(id))
 
         return self._make_request(
-            "POST", f"/2/tweets/search/stream/rules", params=params,
+            "POST", "/2/tweets/search/stream/rules", params=params,
             endpoint_parameters=("dry_run",), json=json, data_type=StreamRule
         )
 
@@ -478,7 +478,7 @@ class StreamingClient(BaseClient, BaseStream):
         https://developer.twitter.com/en/docs/twitter-api/tweets/filtered-stream/api-reference/get-tweets-search-stream-rules
         """
         return self._make_request(
-            "GET", f"/2/tweets/search/stream/rules", params=params,
+            "GET", "/2/tweets/search/stream/rules", params=params,
             endpoint_parameters=("ids",), data_type=StreamRule
         )
 


### PR DESCRIPTION
% `ruff check --select=F541 --fix ` # https://docs.astral.sh/ruff
```
Found 12 errors (12 fixed, 0 remaining).
```
% `ruff rule F541`
# f-string-missing-placeholders (F541)

Derived from the **Pyflakes** linter.

Fix is always available.

## What it does
Checks for f-strings that do not contain any placeholder expressions.

## Why is this bad?
f-strings are a convenient way to format strings, but they are not
necessary if there are no placeholder expressions to format. In this
case, a regular string should be used instead, as an f-string without
placeholders can be confusing for readers, who may expect such a
placeholder to be present.

An f-string without any placeholders could also indicate that the
author forgot to add a placeholder expression.

## Example
```python
f"Hello, world!"
```

Use instead:
```python
"Hello, world!"
```

## References
- [PEP 498](https://www.python.org/dev/peps/pep-0498/)
