### PR TITLE
Fallback to mimetypes if imghdr is not available

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,14 +7,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import sys
 import time
 import unittest
 from ast import literal_eval
@@ -100,14 +101,17 @@ class TweepyAPITests(TweepyTestCase):
         update = self.api.update_status_with_media(tweet_text, 'assets/banner.png')
         self.assertIn(tweet_text + ' https://t.co', update.text)
 
+    @unittest.skipIf(sys.version_info >= (3, 13), "imghdr was removed in Python 3.13")
     @tape.use_cassette('testmediauploadpng.yaml')
     def testmediauploadpng(self):
         self.api.media_upload('assets/banner.png')
 
+    @unittest.skipIf(sys.version_info >= (3, 13), "imghdr was removed in Python 3.13")
     @tape.use_cassette('testmediauploadgif.yaml')
     def testmediauploadgif(self):
         self.api.media_upload('assets/animated.gif')
 
+    @unittest.skipIf(sys.version_info >= (3, 13), "imghdr was removed in Python 3.13")
     @tape.use_cassette('testmediauploadmp4.yaml')
     def testmediauploadmp4(self):
         self.api.media_upload('assets/video.mp4')

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,5 @@
 import os
 import shutil
-import sys
 import time
 import unittest
 from ast import literal_eval
@@ -101,17 +100,14 @@ class TweepyAPITests(TweepyTestCase):
         update = self.api.update_status_with_media(tweet_text, 'assets/banner.png')
         self.assertIn(tweet_text + ' https://t.co', update.text)
 
-    @unittest.skipIf(sys.version_info >= (3, 13), "imghdr was removed in Python 3.13")
     @tape.use_cassette('testmediauploadpng.yaml')
     def testmediauploadpng(self):
         self.api.media_upload('assets/banner.png')
 
-    @unittest.skipIf(sys.version_info >= (3, 13), "imghdr was removed in Python 3.13")
     @tape.use_cassette('testmediauploadgif.yaml')
     def testmediauploadgif(self):
         self.api.media_upload('assets/animated.gif')
 
-    @unittest.skipIf(sys.version_info >= (3, 13), "imghdr was removed in Python 3.13")
     @tape.use_cassette('testmediauploadmp4.yaml')
     def testmediauploadmp4(self):
         self.api.media_upload('assets/video.mp4')

--- a/tweepy/api.py
+++ b/tweepy/api.py
@@ -4,7 +4,6 @@
 
 import contextlib
 import functools
-import imghdr
 import logging
 import mimetypes
 from platform import python_version
@@ -3468,6 +3467,10 @@ class API:
         ----------
         https://developer.twitter.com/en/docs/twitter-api/v1/media/upload-media/overview
         """
+        try:
+            import imghdr
+        except ModuleNotFoundError:
+            raise NotImplementedError("media_upload() is not implemented on Python >= 3.13")
         h = None
         if file is not None:
             location = file.tell()

--- a/tweepy/api.py
+++ b/tweepy/api.py
@@ -3467,19 +3467,22 @@ class API:
         ----------
         https://developer.twitter.com/en/docs/twitter-api/v1/media/upload-media/overview
         """
+        file_type = None
         try:
             import imghdr
         except ModuleNotFoundError:
-            raise NotImplementedError("media_upload() is not implemented on Python >= 3.13")
-        h = None
-        if file is not None:
-            location = file.tell()
-            h = file.read(32)
-            file.seek(location)
-        file_type = imghdr.what(filename, h=h)
-        if file_type is not None:
-            file_type = 'image/' + file_type
+            # imghdr was removed in Python 3.13
+            pass
         else:
+            h = None
+            if file is not None:
+                location = file.tell()
+                h = file.read(32)
+                file.seek(location)
+            file_type = imghdr.what(filename, h=h)
+            if file_type is not None:
+                file_type = 'image/' + file_type
+        if file_type is None:
             file_type = mimetypes.guess_type(filename)[0]
 
         if chunked or file_type.startswith('video/'):


### PR DESCRIPTION
https://github.com/tweepy/tweepy/pull/2181 started the ball rolling by suggesting testing Python 3.13, and raising a `ModuleNotFoundError` if `imghdr` could not be imported when it was to be used.

Since the code already falls back to `mimetypes` if `imghdr` did not return anything
https://github.com/tweepy/tweepy/blob/91a41c6e1c955d278c370d51d5cf43b05f7cd979/tweepy/api.py#L3476-L3480

this PR suggests also falling back to `mimetypes` if `imghdr` is not available at all. The test suite still passes like this.

It does not handle filenames without an extension, like #1086 did, but I imagine it's better than always raising an error in Python 3.13.