### PR TITLE
Add support for posting tweets to Communities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,8 @@ Session.vim
 tags
 
 # End of https://www.gitignore.io/api/vim,python
+
+# vscode
+.vscode
+# Mac OS
+.DS_Store

--- a/cassettes/test_client_create_tweet_with_community.yaml
+++ b/cassettes/test_client_create_tweet_with_community.yaml
@@ -1,0 +1,61 @@
+interactions:
+    - request:
+          body: '{"text": "Test tweet in community", "community_id": "123456789"}'
+          headers:
+              Accept:
+                  - "*/*"
+              Accept-Encoding:
+                  - gzip, deflate
+              Connection:
+                  - keep-alive
+              Content-Length:
+                  - "64"
+              Content-Type:
+                  - application/json
+              User-Agent:
+                  - Python/3.13.1 Requests/2.31.0 Tweepy/4.15.0
+          method: POST
+          uri: https://api.twitter.com/2/tweets
+      response:
+          body:
+              string: '{"data":{"id":"1234567890","text":"Test tweet in community","community_id":"123456789"}}'
+          headers:
+              api-version:
+                  - "2.28"
+              cache-control:
+                  - no-cache, no-store, max-age=0
+              content-disposition:
+                  - attachment; filename=json.json
+              content-length:
+                  - "82"
+              content-type:
+                  - application/json; charset=utf-8
+              date:
+                  - Wed, 10 Feb 2024 11:38:39 UTC
+              location:
+                  - https://api.twitter.com/2/tweets/1234567890
+              server:
+                  - tsa_b
+              strict-transport-security:
+                  - max-age=631138519
+              x-access-level:
+                  - write
+              x-connection-hash:
+                  - f86af2f37d975724d196465ae7a8bb5b420f7b2bb1b541276f76c3fe0569779e
+              x-content-type-options:
+                  - nosniff
+              x-frame-options:
+                  - SAMEORIGIN
+              x-rate-limit-limit:
+                  - "200"
+              x-rate-limit-remaining:
+                  - "199"
+              x-rate-limit-reset:
+                  - "1635976418"
+              x-response-time:
+                  - "226"
+              x-xss-protection:
+                  - "0"
+          status:
+              code: 201
+              message: Created

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,11 @@ Changelog
 
 These changelogs are also at <https://github.com/tweepy/tweepy/releases> as release notes.
 
+Unreleased
+----------
+### New Features / Improvements
+- Add support for posting tweets to Communities via `community_id` parameter in `Client.create_tweet`
+
 Version 4.15.0 (2025-01-15)
 ---------------------------
 - Fix error "No module named 'imghdr'" due to removed package in Python 3.13+
@@ -1209,3 +1214,7 @@ Version 1.0.1 (2009-09-13)
 Version 1.0 (2009-08-13)
 ------------------------
 <https://github.com/tweepy/tweepy/commits/e62f8c18977fd755c9d24a0abebd3b8087c75b45>
+
+
+
+

--- a/examples/API_v2/create_tweet.py
+++ b/examples/API_v2/create_tweet.py
@@ -22,7 +22,16 @@ client = tweepy.Client(
 # Make sure to reauthorize your app / regenerate your access token and secret 
 # after setting the Write permission
 
+# Example 1: Create a regular Tweet
 response = client.create_tweet(
     text="This Tweet was Tweeted using Tweepy and Twitter API v2!"
 )
 print(f"https://twitter.com/user/status/{response.data['id']}")
+
+# Example 2: Create a Tweet in a Community
+# Note: The authenticated user must be a member of the Community
+# response = client.create_tweet(
+#     text="This Tweet was posted in a Community using Tweepy and Twitter API v2!",
+#     community_id="INSERT_COMMUNITY_ID_HERE"
+# )
+# print(f"https://twitter.com/user/status/{response.data['id']}")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -257,3 +257,12 @@ class TweepyClientTests(unittest.TestCase):
         job_id = response.data["id"]
         self.client.get_compliance_job(job_id)
         self.client.get_compliance_jobs("tweets")
+
+    @tape.use_cassette("test_client_create_tweet_with_community.yaml")
+    def test_create_tweet_with_community(self):
+        response = self.client.create_tweet(
+            text="Test tweet in community",
+            community_id="123456789"
+        )
+        assert response.data["text"] == "Test tweet in community"
+        assert "community_id" in response.data

--- a/tweepy/client.py
+++ b/tweepy/client.py
@@ -539,7 +539,7 @@ class Client(BaseClient):
             tweet_fields=None, user_fields=None, user_auth=False \
         )
 
-        Allows you to get information about a Tweet’s liking users.
+        Allows you to get information about a Tweet's liking users.
 
         .. versionchanged:: 4.6
             Added ``max_results`` and ``pagination_token`` parameters
@@ -597,7 +597,7 @@ class Client(BaseClient):
             tweet_fields=None, user_fields=None, user_auth=False \
         )
 
-        Allows you to get information about a user’s liked Tweets.
+        Allows you to get information about a user's liked Tweets.
 
         The Tweets returned by this endpoint count towards the Project-level
         `Tweet cap`_.
@@ -731,7 +731,7 @@ class Client(BaseClient):
         place_id=None, media_ids=None, media_tagged_user_ids=None,
         poll_duration_minutes=None, poll_options=None, quote_tweet_id=None,
         exclude_reply_user_ids=None, in_reply_to_tweet_id=None,
-        reply_settings=None, text=None, user_auth=True
+        reply_settings=None, text=None, user_auth=True, community_id=None
     ):
         """Creates a Tweet on behalf of an authenticated user.
 
@@ -780,6 +780,9 @@ class Client(BaseClient):
             ``media.media_ids`` is not present.
         user_auth : bool
             Whether or not to use OAuth 1.0a User Context to authenticate
+        community_id : int | str | None
+            The ID of the Community to tweet in. The authenticated user must be a
+            member of the Community.
 
         Returns
         -------
@@ -798,6 +801,9 @@ class Client(BaseClient):
         if direct_message_deep_link is not None:
             json["direct_message_deep_link"] = direct_message_deep_link
 
+        if community_id is not None:
+            json["community_id"] = community_id
+            
         if for_super_followers_only is not None:
             json["for_super_followers_only"] = for_super_followers_only
 


### PR DESCRIPTION
## Description
Add support for posting tweets to Communities using the Twitter API v2 endpoint. This adds a new `community_id` parameter to the `Client.create_tweet` method.

## Changes
- Add `community_id` parameter to `Client.create_tweet`
- Add example for creating tweets in Communities
- Add test case for community tweets
- Update changelog

## Requirements
- Users must be members of the Community to post tweets in it

## Related Issues
Fixes #2219

## Testing
- Added test case `test_create_tweet_with_community`
- All tests passing