### PR TITLE
 [Feature] Distinguish Twitter API 429 errors for rate limits vs. monthly post cap

### DIFF
--- a/tweepy/client.py
+++ b/tweepy/client.py
@@ -115,6 +115,7 @@ class BaseClient:
                                 "Rate limit exceeded. "
                                 f"Sleeping for {sleep_time} seconds."
                             )
+                            # If 429 is returned even after exceeding the specified number of times → Possibility of monthly cap
                             if self._rate_limit_retry_count >= self._max_rate_limit_retries:
                                 logger.warning(
                                     "Still receiving 429 after multiple waits. "


### PR DESCRIPTION
This pull request addresses an ambiguity in handling 429 "Too Many Requests" errors from the Twitter API. A 429 response can be caused by two distinct issues:

1. Rate limiting: A temporary limit on the number of requests within a specific time window. This is usually resolved by waiting for a period.

2. Monthly post cap: The account has exceeded its allocated monthly post limit, which is a hard limit and cannot be resolved by simply waiting.

The current implementation treats all 429 errors as temporary rate limits, leading to unnecessary retries that will continue to fail if the monthly post cap has been reached.

Proposed Changes:
This PR introduces a new retry strategy.

* When a 429 is received, the system will pause and retry the request using an exponential backoff strategy.

* If the request fails with a 429 after N retries (in default, N is 3), we can confidently infer that the issue is not a temporary rate limit.

* At this point, the application will display a user-facing warning, guiding them to check their monthly usage and upgrade their plan if necessary.

This change improves the user experience by providing a clear explanation for the persistent API errors and prevents our systems from making futile requests.