### PR TITLE
Replace deprecated datetime.utcnow() in MongodbCache.store

### DIFF
--- a/tweepy/cache.py
+++ b/tweepy/cache.py
@@ -400,7 +400,7 @@ class MongodbCache(Cache):
     def store(self, key, value):
         from bson.binary import Binary
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(datetime.timezone.utc)
         blob = Binary(pickle.dumps(value))
 
         self.col.insert({'created': now, '_id': key, 'value': blob})


### PR DESCRIPTION
## Summary

`MongodbCache.store()` uses `datetime.datetime.utcnow()`:

```python
now = datetime.datetime.utcnow()
...
self.col.insert({'created': now, '_id': key, 'value': blob})
```

`datetime.utcnow()` is deprecated since Python 3.12 and emits a `DeprecationWarning` (it's scheduled for removal). tweepy supports Python 3.9–3.13.

## Fix

Replace with `datetime.datetime.now(datetime.timezone.utc)`.

## Behavior is preserved

The `created` value feeds a MongoDB TTL index (`self.col.create_index('created', expireAfterSeconds=timeout)`). MongoDB stores all dates as UTC, and PyMongo serializes **both**:
- a naive `utcnow()` value (interpreted as UTC), and
- a timezone-aware `now(timezone.utc)` value

to the **same UTC instant**. So the stored value and TTL-expiry behavior are unchanged — this is purely removing the deprecation.

## Verification

```python
import warnings, datetime
warnings.simplefilter("error", DeprecationWarning)
datetime.datetime.utcnow()
# DeprecationWarning: datetime.datetime.utcnow() is deprecated ...

datetime.datetime.now(datetime.timezone.utc)   # clean, tz-aware UTC
```

Single-line change; `cache.py` parses and imports fine.
